### PR TITLE
Update to the latest rdkafka

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ jmespatch = { version = "0.3", features = ["sync"] }
 lazy_static = "1"
 log = "0"
 maplit = "1"
-rdkafka = "0.25"
+rdkafka = "0.26"
 rusoto_core = { version = "0.46" }
 rusoto_credential = { version = "0.46" }
 rusoto_s3 = { version = "0.46" }


### PR DESCRIPTION
The 0.26 release has a couple bug fixes, most notably a fix to compile on aarch64 

https://github.com/fede1024/rust-rdkafka/compare/v0.25.0...v0.26.0