### PR TITLE
[REF] Missing min/max in parquet stats for array types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,8 +44,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrow"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=05b36567bd8216bec71b796fe3bb6811c71abbec#05b36567bd8216bec71b796fe3bb6811c71abbec"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014c7490f839d9dd4ce28f8232d4731f8b1fb93fa477d69e6fe881814ac2b6bb"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -313,8 +314,8 @@ dependencies = [
 
 [[package]]
 name = "deltalake"
-version = "0.2.1"
-source = "git+https://github.com/delta-io/delta-rs.git?rev=9cb718f64aa8abfdb00a1163bb400a3949c208a3#9cb718f64aa8abfdb00a1163bb400a3949c208a3"
+version = "0.3.0"
+source = "git+https://github.com/delta-io/delta-rs.git?rev=83b8296fa5d55ebe050b022ed583dc57152221fe#83b8296fa5d55ebe050b022ed583dc57152221fe"
 dependencies = [
  "anyhow",
  "arrow",
@@ -795,6 +796,7 @@ dependencies = [
  "log",
  "maplit",
  "parquet",
+ "parquet-format",
  "rdkafka",
  "rusoto_core",
  "rusoto_credential",
@@ -1158,8 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=05b36567bd8216bec71b796fe3bb6811c71abbec#05b36567bd8216bec71b796fe3bb6811c71abbec"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32858ae16bd61fda406be4b76af617d2f632fed4f0093810245aa4f5316ac865"
 dependencies = [
  "arrow",
  "base64 0.12.3",
@@ -1380,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8acd8f5c5482fdf89e8878227bafa442d8c4409f6287391c85549ca83626c27"
+checksum = "af78bc431a82ef178c4ad6db537eb9cc25715a8591d27acc30455ee7227a76f4"
 dependencies = [
  "futures",
  "libc",
@@ -1397,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "3.0.0+1.6.0"
+version = "4.0.0+1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca35e95c88e08cdc643b25744e38ccee7c93c7e90d1ac6850fe74cbaa40803c3"
+checksum = "54f24572851adfeb525fdc4a1d51185898e54fed4e8d8dba4fadb90c6b4f0422"
 dependencies = [
  "libc",
  "libz-sys",
@@ -2249,18 +2252,18 @@ checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 
 [[package]]
 name = "zstd"
-version = "0.6.1+zstd.1.4.9"
+version = "0.7.0+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de55e77f798f205d8561b8fe2ef57abfb6e0ff2abe7fd3c089e119cdb5631a3"
+checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "3.0.1+zstd.1.4.9"
+version = "3.1.0+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1387cabcd938127b30ce78c4bf00b30387dddf704e3f0881dbc4ff62b5566f8c"
+checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -2268,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.20+zstd.1.4.9"
+version = "1.5.0+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd5b733d7cf2d9447e2c3e76a5589b4f5e5ae065c22a2bc0b023cbc331b6c8e"
+checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ jmespatch = { version = "0.3", features = ["sync"] }
 lazy_static = "1"
 log = "0"
 maplit = "1"
+# Version of parquet-format from https://github.com/apache/arrow-rs/blob/486524733639d3c9e60e44bb07a65c628958b7b6/parquet/Cargo.toml#L34
 parquet-format = "~2.6.1"
 rdkafka = "0.26"
 rusoto_core = { version = "0.46" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,7 @@ tokio-util = "0.6.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 arrow = { version = "4" }
-# arrow  = { git = "https://github.com/apache/arrow.git", rev = "9c1e5bd19347635ea9f373bcf93f2cea0231d50a" }
 deltalake = { git = "https://github.com/delta-io/delta-rs.git", rev = "83b8296fa5d55ebe050b022ed583dc57152221fe" }
-# parquet = { git = "https://github.com/apache/arrow.git", rev = "9c1e5bd19347635ea9f373bcf93f2cea0231d50a" }
 parquet = { version = "4" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ jmespatch = { version = "0.3", features = ["sync"] }
 lazy_static = "1"
 log = "0"
 maplit = "1"
+parquet-format = "~2.6.1"
 rdkafka = "0.26"
 rusoto_core = { version = "0.46" }
 rusoto_credential = { version = "0.46" }
@@ -28,9 +29,11 @@ tokio-stream = { version = "0", features = ["fs"] }
 tokio-util = "0.6.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
-arrow  = { git = "https://github.com/apache/arrow.git", rev = "05b36567bd8216bec71b796fe3bb6811c71abbec" }
-deltalake = { git = "https://github.com/delta-io/delta-rs.git", rev = "9cb718f64aa8abfdb00a1163bb400a3949c208a3" }
-parquet = { git = "https://github.com/apache/arrow.git", rev = "05b36567bd8216bec71b796fe3bb6811c71abbec" }
+arrow = { version = "4" }
+# arrow  = { git = "https://github.com/apache/arrow.git", rev = "9c1e5bd19347635ea9f373bcf93f2cea0231d50a" }
+deltalake = { git = "https://github.com/delta-io/delta-rs.git", rev = "83b8296fa5d55ebe050b022ed583dc57152221fe" }
+# parquet = { git = "https://github.com/apache/arrow.git", rev = "9c1e5bd19347635ea9f373bcf93f2cea0231d50a" }
+parquet = { version = "4" }
 
 [dev-dependencies]
 utime = "0.3"

--- a/tests/parquet_stats.rs
+++ b/tests/parquet_stats.rs
@@ -24,6 +24,9 @@ fn inspect_parquet_footer() {
 
     let file_metadata = arrow_writer.close().unwrap();
 
+    // write out file for inspection
+    std::fs::write("../parquet_footer_test.parquet", cursor.data()).unwrap();
+
     for rg in file_metadata.row_groups.iter() {
         for c in rg.columns.iter() {
             let metadata = c.meta_data.as_ref().unwrap();

--- a/tests/parquet_stats.rs
+++ b/tests/parquet_stats.rs
@@ -1,0 +1,350 @@
+use arrow::{datatypes::Schema as ArrowSchema, error::ArrowError, json::reader::Decoder};
+use deltalake::Schema as DeltaSchema;
+use parquet::{arrow::ArrowWriter, file::writer::InMemoryWriteableCursor};
+use serde_json::{json, Value};
+use std::convert::TryFrom;
+use std::sync::Arc;
+
+#[test]
+fn inspect_parquet_footer() {
+    // let arrow_schema = example_arrow_schema_from_delta();
+    let arrow_schema = example_arrow_schema_from_json();
+
+    let cursor = InMemoryWriteableCursor::default();
+
+    let mut arrow_writer =
+        ArrowWriter::try_new(cursor.clone(), arrow_schema.clone(), None).unwrap();
+
+    let json_data = example_data();
+    let mut json_iter = InMemValueIter::from_vec(json_data.as_slice());
+    let decoder = Decoder::new(arrow_schema.clone(), json_data.len(), None);
+    let batch = decoder.next_batch(&mut json_iter).unwrap().unwrap();
+
+    arrow_writer.write(&batch).unwrap();
+
+    let file_metadata = arrow_writer.close().unwrap();
+
+    for rg in file_metadata.row_groups.iter() {
+        for c in rg.columns.iter() {
+            let metadata = c.meta_data.as_ref().unwrap();
+            let stats = metadata.statistics.as_ref().unwrap();
+
+            println!("Path: {:?}", metadata.path_in_schema);
+
+            if let None = stats.min_value.as_ref() {
+                println!("NO min/max");
+            } else {
+                println!("Has min/max");
+            }
+        }
+    }
+}
+
+fn example_arrow_schema_from_delta() -> Arc<ArrowSchema> {
+    let delta_schema = example_delta_schema();
+    let arrow_schema = <ArrowSchema as TryFrom<&DeltaSchema>>::try_from(&delta_schema).unwrap();
+
+    Arc::new(arrow_schema)
+}
+
+fn example_arrow_schema_from_json() -> Arc<ArrowSchema> {
+    let schema_json = json!(
+    {
+      "fields": [
+        {
+          "name": "some_nested_object",
+          "nullable": true,
+          "type": {
+            "name": "struct"
+          },
+          "children": [
+            {
+              "name": "kafka",
+              "nullable": true,
+              "type": {
+                "name": "struct"
+              },
+              "children": [
+                {
+                  "name": "offset",
+                  "nullable": true,
+                  "type": {
+                    "name": "int",
+                    "bitWidth": 64,
+                    "isSigned": true
+                  },
+                  "children": []
+                },
+                {
+                  "name": "topic",
+                  "nullable": true,
+                  "type": {
+                    "name": "utf8"
+                  },
+                  "children": []
+                },
+                {
+                  "name": "partition",
+                  "nullable": true,
+                  "type": {
+                    "name": "int",
+                    "bitWidth": 32,
+                    "isSigned": true
+                  },
+                  "children": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "some_int_array",
+          "nullable": true,
+          "type": {
+            "name": "list"
+          },
+          "children": [
+            {
+              "name": "element",
+              "nullable": false,
+              "type": {
+                "name": "int",
+                "bitWidth": 32,
+                "isSigned": true
+              },
+              "children": []
+            }
+          ]
+        },
+        {
+          "name": "some_struct_array",
+          "nullable": true,
+          "type": {
+            "name": "list"
+          },
+          "children": [
+            {
+              "name": "element",
+              "nullable": false,
+              "type": {
+                "name": "struct"
+              },
+              "children": [
+                {
+                  "name": "id",
+                  "nullable": true,
+                  "type": {
+                    "name": "utf8"
+                  },
+                  "children": []
+                },
+                {
+                  "name": "value",
+                  "nullable": true,
+                  "type": {
+                    "name": "utf8"
+                  },
+                  "children": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "some_string",
+          "nullable": true,
+          "type": {
+            "name": "utf8"
+          },
+          "children": []
+        },
+        {
+          "name": "some_int",
+          "nullable": true,
+          "type": {
+            "name": "int",
+            "bitWidth": 32,
+            "isSigned": true
+          },
+          "children": []
+        }
+      ],
+      "metadata": {}
+    }
+    );
+    todo!()
+}
+
+fn example_delta_schema() -> DeltaSchema {
+    let schema_json = json!({
+      "type": "struct",
+      "fields": [
+        {
+          "name": "some_nested_object",
+          "type": {
+            "type": "struct",
+            "fields": [
+              {
+                "name": "kafka",
+                "type": {
+                  "type": "struct",
+                  "fields": [
+                    {
+                      "name": "offset",
+                      "type": "long",
+                      "nullable": true,
+                      "metadata": {}
+                    },
+                    {
+                      "name": "topic",
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {}
+                    },
+                    {
+                      "name": "partition",
+                      "type": "integer",
+                      "nullable": true,
+                      "metadata": {}
+                    }
+                  ]
+                },
+                "nullable": true,
+                "metadata": {}
+              }
+            ]
+          },
+          "nullable": true,
+          "metadata": {}
+        },
+        {
+          "name": "some_int_array",
+          "type": {
+            "type": "array",
+            "elementType": "integer",
+            "containsNull": false
+          },
+          "nullable": true,
+          "metadata": {}
+        },
+        {
+          "name": "some_struct_array",
+          "type": {
+            "type": "array",
+            "elementType": {
+              "type": "struct",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {}
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {}
+                }
+              ]
+            },
+            "containsNull": false
+          },
+          "nullable": true,
+          "metadata": {}
+        },
+        {
+          "name": "some_string",
+          "type": "string",
+          "nullable": true,
+          "metadata": {}
+        },
+        {
+          "name": "some_int",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {}
+        },
+      ]
+    });
+
+    let schema_string = serde_json::to_string(&schema_json).unwrap();
+    serde_json::from_str(&&schema_string).unwrap()
+}
+
+fn example_data() -> Vec<Value> {
+    vec![
+        json!({
+            "some_nested_object": {
+                "kafka": { "offset": 1, "partition": 0i64, "topic": "A" }
+            },
+            "some_int_array": [0, 1, 4],
+            "some_struct_array": [{
+                "id": "xyz",
+                "value": "abc",
+            }],
+            "some_string": "hello world",
+            "some_int": 11,
+        }),
+        json!({
+            "some_nested_object": {
+                "kafka": { "topic": "A" }
+            },
+            "some_struct_array": [{
+                "id": "pqr",
+                "value": "tuv",
+            }],
+            "some_string": "hello world",
+            "some_int": 42,
+        }),
+        json!({
+            "some_nested_object": {
+                "kafka": { "offset": 2, "partition": 3i64, "topic": "A" }
+            },
+            "some_int_array": [0, 1],
+            "some_struct_array": [{
+                "id": "pqr",
+                "value": "tuv",
+            }],
+            "some_string": "hello world",
+        }),
+        json!({
+            "some_nested_object": {
+                "kafka": { "offset": 2, "partition": 0i64, "topic": "A" }
+            },
+            "some_int_array": [0, 1, 2, 3],
+            "some_struct_array": [{
+                "id": "xyz",
+                "value": "abc",
+            }],
+            "some_string": "hello world",
+            "some_int": 11,
+        }),
+    ]
+}
+
+struct InMemValueIter<'a> {
+    buffer: &'a [Value],
+    current_index: usize,
+}
+
+impl<'a> InMemValueIter<'a> {
+    fn from_vec(v: &'a [Value]) -> Self {
+        Self {
+            buffer: v,
+            current_index: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for InMemValueIter<'a> {
+    type Item = Result<Value, ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.buffer.get(self.current_index);
+
+        self.current_index += 1;
+
+        item.map(|v| Ok(v.to_owned()))
+    }
+}

--- a/tests/parquet_stats.rs
+++ b/tests/parquet_stats.rs
@@ -172,7 +172,8 @@ fn example_arrow_schema_from_json() -> Arc<ArrowSchema> {
       "metadata": {}
     }
     );
-    todo!()
+
+    Arc::new(ArrowSchema::from(&schema_json).unwrap())
 }
 
 fn example_delta_schema() -> DeltaSchema {


### PR DESCRIPTION
Min/max values appear to be missing from stats for array types.  Spark includes these in column chunk metadata as the overall min and max from any value contained in any array for the chunk.

Output of `RUST_LOG=debug cargo test -- --nocapture --test inspect_parquet_footer`

```
Path: ["some_nested_object", "kafka", "offset"]
Has min/max
Path: ["some_nested_object", "kafka", "topic"]
Has min/max
Path: ["some_nested_object", "kafka", "partition"]
Has min/max
Path: ["some_int_array", "list", "item"]
NO min/max
Path: ["some_struct_array", "list", "element", "id"]
NO min/max
Path: ["some_struct_array", "list", "element", "value"]
NO min/max
Path: ["some_string"]
Has min/max
Path: ["some_int"]
Has min/max
```

Example inspection of parquet metadata for same array column schema written by Spark (different values were inserted with Spark than used in the test within this repo, but min and max are set:

```
>>> parquet_file.metadata.row_group(0).column(0)
<pyarrow._parquet.ColumnChunkMetaData object at 0x1099de950>
  file_offset: 4
  file_path:
  physical_type: INT32
  num_values: 15
  path_in_schema: some_int_array.list.element
  is_stats_set: True
  statistics:
    <pyarrow._parquet.Statistics object at 0x1099d7bf0>
      has_min_max: True
      min: 0
      max: 101
      null_count: 0
      distinct_count: 0
      num_values: 15
      physical_type: INT32
      logical_type: None
      converted_type (legacy): NONE
  compression: SNAPPY
  encodings: ('RLE', 'PLAIN_DICTIONARY')
  has_dictionary_page: False
  dictionary_page_offset: None
  data_page_offset: 4
  total_compressed_size: 142
  total_uncompressed_size: 141
```

Supercedes https://github.com/delta-io/kafka-delta-ingest/pull/14