### PR TITLE
Add its own commit loop which resolves partition offsets conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "0.4.0"
-source = "git+https://github.com/delta-io/delta-rs.git?rev=4d033d6be1e140d61cf7685d60c1c05bc3d72146#4d033d6be1e140d61cf7685d60c1c05bc3d72146"
+source = "git+https://github.com/delta-io/delta-rs.git?rev=e48336d4c602028b240ebd0cb69d9bb45af666ee#e48336d4c602028b240ebd0cb69d9bb45af666ee"
 dependencies = [
  "anyhow",
  "arrow",
@@ -375,6 +375,7 @@ dependencies = [
  "log",
  "maplit",
  "parquet",
+ "parquet-format",
  "regex",
  "rusoto_core",
  "rusoto_credential",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tokio-util = "0.6.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 arrow  = { version = "4" }
-deltalake = { git = "https://github.com/delta-io/delta-rs.git", rev = "4d033d6be1e140d61cf7685d60c1c05bc3d72146", features = ["s3", "dynamodb"] }
+deltalake = { git = "https://github.com/delta-io/delta-rs.git", rev = "e48336d4c602028b240ebd0cb69d9bb45af666ee", features = ["s3"] }
 parquet = { version = "4" }
 
 [dev-dependencies]

--- a/src/deltalake_ext.rs
+++ b/src/deltalake_ext.rs
@@ -90,7 +90,7 @@ pub enum DeltaWriterError {
 }
 
 pub struct DeltaWriter {
-    table: DeltaTable,
+    pub table: DeltaTable,
     storage: Box<dyn StorageBackend>,
     arrow_schema_ref: Arc<arrow::datatypes::Schema>,
     writer_properties: WriterProperties,

--- a/src/deltalake_ext.rs
+++ b/src/deltalake_ext.rs
@@ -12,7 +12,7 @@ use deltalake::{
     DeltaDataTypeVersion, DeltaTable, DeltaTableError, DeltaTransactionError, Schema,
     StorageBackend, StorageError, UriError,
 };
-use log::{debug, info};
+use log::debug;
 use parquet::{
     arrow::ArrowWriter,
     basic::{Compression, LogicalType},
@@ -140,17 +140,23 @@ impl DeltaWriter {
         })
     }
 
-    pub fn last_transaction_version(
-        &self,
-        app_id: &str,
-    ) -> Result<Option<DeltaDataTypeVersion>, DeltaWriterError> {
+    pub fn last_transaction_version(&self, app_id: &str) -> Option<DeltaDataTypeVersion> {
         let tx_versions = self.table.get_app_transaction_version();
 
         let v = tx_versions.get(app_id).map(|v| v.to_owned());
 
         debug!("Transaction version is {:?} for {}", v, app_id);
 
-        Ok(v)
+        v
+    }
+
+    pub async fn update_table(&mut self) -> Result<(), DeltaWriterError> {
+        self.table.update().await?;
+        Ok(())
+    }
+
+    pub fn table_version(&self) -> DeltaDataTypeVersion {
+        self.table.version
     }
 
     /// Writes the record batch in-memory and updates internal state accordingly.
@@ -189,11 +195,7 @@ impl DeltaWriter {
     }
 
     /// Writes the existing parquet bytes to storage and resets internal state to handle another file.
-    pub async fn write_file(
-        &mut self,
-        actions: Vec<Action>,
-    ) -> Result<DeltaDataTypeVersion, DeltaWriterError> {
-        let mut actions = actions;
+    pub async fn write_parquet_file(&mut self) -> Result<Add, DeltaWriterError> {
         debug!("Writing parquet file.");
 
         let metadata = self.arrow_writer.close()?;
@@ -220,20 +222,22 @@ impl DeltaWriter {
         // After data is written, re-initialize internal state to handle another file
         self.reset()?;
 
-        debug!("Writing Delta transaction.");
+        Ok(create_add(
+            &self.partition_values,
+            path,
+            file_size,
+            &metadata,
+        )?)
+    }
 
-        let add = create_add(&self.partition_values, path, file_size, &metadata)?;
-
-        actions.push(Action::add(add));
-
-        // TODO: Pass StreamingUpdate operation
+    pub async fn commit_version(
+        &mut self,
+        version: DeltaDataTypeVersion,
+        actions: Vec<Action>,
+    ) -> Result<DeltaDataTypeVersion, DeltaTransactionError> {
         let mut tx = self.table.create_transaction(None);
         tx.add_actions(actions);
-        let version = tx.commit(None).await?;
-
-        info!("Committed Delta version {}", version);
-
-        Ok(version)
+        tx.commit_version(version, None).await
     }
 
     pub fn buffered_record_batch_count(&self) -> usize {

--- a/src/deltalake_ext.rs
+++ b/src/deltalake_ext.rs
@@ -244,7 +244,7 @@ impl DeltaWriter {
         self.buffered_record_batch_count
     }
 
-    fn reset(&mut self) -> Result<(), DeltaWriterError> {
+    pub fn reset(&mut self) -> Result<(), DeltaWriterError> {
         // Reset the internal cursor for the next file.
         self.cursor = InMemoryWriteableCursor::default();
         // Reset buffered record batch count to 0.

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -75,7 +75,7 @@ pub trait Instrumentation {
         m: &BorrowedMessage,
         message_buffer_len: usize,
     ) {
-        info_message("Message received on untracked partition, but no Delta Log or WAL entry exists yet. Buffering message", m);
+        info_message("Message received on untracked partition, but no Delta Log entry exists yet. Buffering message", m);
         self.record_stat((StatTypes::MessageBuffered, 1)).await;
         self.record_stat((StatTypes::BufferedMessages, message_buffer_len as i64))
             .await;
@@ -108,13 +108,13 @@ pub trait Instrumentation {
     // delta writes
 
     async fn log_delta_write_started(&self) {
-        info!("Delta write started");
+        debug!("Delta write started");
         self.record_stat((StatTypes::DeltaWriteStarted, 1)).await;
     }
 
     async fn log_delta_write_completed(&self, version: DeltaDataTypeVersion, timer: &Instant) {
         let duration = timer.elapsed().as_micros() as i64;
-        debug!(
+        info!(
             "Delta write for version {} has completed in {} microseconds",
             version, duration
         );

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -67,20 +67,8 @@ pub trait Instrumentation {
     // assignments
 
     async fn log_assignment_untracked_skipped(&self, m: &BorrowedMessage) {
-        info_message("Partition is not tracked but a delta tx exists. Updating partition assignment and skipping message. Will process the same message again after consumer seek", m);
+        info_message("Partition is not tracked. Resetting partition assignment and skipping message. Will process the same message again after consumer seek.", m);
     }
-
-    async fn log_assignment_untracked_buffered(
-        &self,
-        m: &BorrowedMessage,
-        message_buffer_len: usize,
-    ) {
-        info_message("Message received on untracked partition, but no Delta Log entry exists yet. Buffering message", m);
-        self.record_stat((StatTypes::MessageBuffered, 1)).await;
-        self.record_stat((StatTypes::BufferedMessages, message_buffer_len as i64))
-            .await;
-    }
-
     // record batches
 
     async fn log_record_batch_started(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,9 +463,9 @@ impl KafkaJsonToDelta {
             let mut txns = Vec::new();
             for (partition, offset) in partition_offsets {
                 let txn = action::Action::txn(action::Txn {
-                    appId: self.app_id_for_partition(partition),
+                    app_id: self.app_id_for_partition(partition),
                     version: offset,
-                    lastUpdated: std::time::SystemTime::now()
+                    last_updated: std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap()
                         .as_millis() as i64,
@@ -475,7 +475,7 @@ impl KafkaJsonToDelta {
             }
 
             self.log_delta_write_started().await;
-            let commit_result = state.delta_writer.write_file(&mut txns).await;
+            let commit_result = state.delta_writer.write_file(txns).await;
             match commit_result {
                 Ok(version) => {
                     self.log_delta_write_completed(version, &delta_write_timer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,7 +597,7 @@ impl KafkaJsonToDelta {
 
             if let Some(version) = version {
                 // if messages in kafka are consecutive then offset should always be `version+1` for
-                // safe commit, but since it's no guaranteed by kafka, we only check for `less than`.
+                // safe commit, but since kafka does not guarantee contiguous offsets, we only check for `less than`.
                 if *offset != version {
                     info!(
                         "Conflict offset for partition {}: state={:?}, delta={:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,7 @@ impl KafkaJsonToDelta {
             partition_assignment.reset_with(&partitions);
             self.reset_state(state, &mut partition_assignment).await?;
 
-            // clear `rebalance` list only if reset state i successful
+            // clear `rebalance` list only if reset state is successful
             partition_assignment.rebalance = None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,9 @@ impl KafkaJsonToDelta {
         let mut value = self.deserialize_message(msg).await?;
         self.transform_value(&mut value, msg).await?;
 
-        state.value_buffers.add(msg.partition(), msg.offset(), value);
+        state
+            .value_buffers
+            .add(msg.partition(), msg.offset(), value);
 
         Ok(())
     }
@@ -432,12 +434,16 @@ impl KafkaJsonToDelta {
         Ok(())
     }
 
-    fn check_message_tracking(&self, state: &mut ProcessingState, msg: &BorrowedMessage<'_>) -> Result<(), ProcessingError> {
+    fn check_message_tracking(
+        &self,
+        state: &mut ProcessingState,
+        msg: &BorrowedMessage<'_>,
+    ) -> Result<(), ProcessingError> {
         if let Some(offset) = state.partition_offsets.get(&msg.partition()) {
             if *offset > msg.offset() {
                 // This message was consumed after rebalance but before the seek.
                 // Then next consumption will get us the messages with expected offsets
-                return Err(ProcessingError::Continue)
+                return Err(ProcessingError::Continue);
             }
         }
 

--- a/tests/emails_s3_tests.rs
+++ b/tests/emails_s3_tests.rs
@@ -28,7 +28,7 @@ const TEST_APP_ID: &str = "emails_test";
 const TEST_BROKER: &str = "0.0.0.0:9092";
 const TEST_CONSUMER_GROUP_ID: &str = "kafka_delta_ingest_emails";
 const TEST_PARTITIONS: i32 = 4;
-const TEST_TOTAL_MESSAGES: i32 = 100;
+const TEST_TOTAL_MESSAGES: i32 = 200;
 
 const WORKER_1: &str = "WORKER-1";
 const WORKER_2: &str = "WORKER-2";
@@ -63,11 +63,11 @@ async fn run_emails_s3_tests(initiate_rebalance: bool) {
     // otherwise, to proceed without rebalance the two workers has to be created simultaneously
     let w2 = if initiate_rebalance {
         scope.send_messages(TEST_TOTAL_MESSAGES).await;
-        thread::sleep(Duration::from_secs(2));
+        thread::sleep(Duration::from_secs(1));
         scope.create_and_start(WORKER_2).await
     } else {
         let w = scope.create_and_start(WORKER_2).await;
-        thread::sleep(Duration::from_secs(5));
+        thread::sleep(Duration::from_secs(4));
         scope.send_messages(TEST_TOTAL_MESSAGES).await;
         w
     };

--- a/tests/emails_s3_tests.rs
+++ b/tests/emails_s3_tests.rs
@@ -28,7 +28,7 @@ const TEST_APP_ID: &str = "emails_test";
 const TEST_BROKER: &str = "0.0.0.0:9092";
 const TEST_CONSUMER_GROUP_ID: &str = "kafka_delta_ingest_emails";
 const TEST_PARTITIONS: i32 = 4;
-const TEST_TOTAL_MESSAGES: i32 = 100;
+const TEST_TOTAL_MESSAGES: i32 = 150;
 
 const WORKER_1: &str = "WORKER-1";
 const WORKER_2: &str = "WORKER-2";

--- a/tests/emails_s3_tests.rs
+++ b/tests/emails_s3_tests.rs
@@ -28,7 +28,7 @@ const TEST_APP_ID: &str = "emails_test";
 const TEST_BROKER: &str = "0.0.0.0:9092";
 const TEST_CONSUMER_GROUP_ID: &str = "kafka_delta_ingest_emails";
 const TEST_PARTITIONS: i32 = 4;
-const TEST_TOTAL_MESSAGES: i32 = 200;
+const TEST_TOTAL_MESSAGES: i32 = 100;
 
 const WORKER_1: &str = "WORKER-1";
 const WORKER_2: &str = "WORKER-2";

--- a/tests/emails_s3_tests.rs
+++ b/tests/emails_s3_tests.rs
@@ -103,8 +103,7 @@ async fn run_emails_s3_tests(initiate_rebalance: bool) {
     dummy_messages_token.cancel();
     dummy_messages_handle.await.unwrap();
 
-    // the conflict resolution should be done before enabling these checks
-    // scope.validate_data().await;
+    scope.validate_data().await;
     scope.shutdown();
 }
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -74,6 +74,8 @@ pub async fn read_files_from_s3(paths: Vec<String>) -> Vec<i32> {
         }
     }
 
+    std::fs::remove_file(tmp).unwrap();
+
     list.sort();
     list
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -165,14 +165,14 @@ async fn e2e_smoke_test() {
         _ => panic!(),
     };
 
-    assert_eq!(2, stats.numRecords);
+    assert_eq!(2, stats.num_records);
     assert_eq!(
         "1",
-        stats.minValues["id"].as_value().unwrap().as_str().unwrap()
+        stats.min_values["id"].as_value().unwrap().as_str().unwrap()
     );
     assert_eq!(
         1,
-        stats.minValues["value"]
+        stats.min_values["value"]
             .as_value()
             .unwrap()
             .as_i64()
@@ -180,11 +180,11 @@ async fn e2e_smoke_test() {
     );
     assert_eq!(
         "2",
-        stats.maxValues["id"].as_value().unwrap().as_str().unwrap()
+        stats.max_values["id"].as_value().unwrap().as_str().unwrap()
     );
     assert_eq!(
         2,
-        stats.maxValues["value"]
+        stats.max_values["value"]
             .as_value()
             .unwrap()
             .as_i64()


### PR DESCRIPTION
Fixes #25


Here's log from tests right after the new consumer is added to the group:
```
2021-06-10T16:36:16 [INFO] - WORKER-1: Delta write for version 5 has completed in 602071 microseconds
2021-06-10T16:36:16 [INFO] - WORKER-2: Starting run loop.
2021-06-10T16:36:17 [INFO] - WORKER-1: Delta write for version 6 has completed in 516716 microseconds
2021-06-10T16:36:17 [INFO] - WORKER-1: REBALANCE - Received new partition assignment list [1, 0]
2021-06-10T16:36:17 [INFO] - WORKER-2: REBALANCE - Received new partition assignment list [2, 3]
2021-06-10T16:36:17 [INFO] - WORKER-2: Resetting state with partitions: [3, 2]
2021-06-10T16:36:17 [INFO] - WORKER-2: Seeking consumer to 3:9
2021-06-10T16:36:17 [INFO] - WORKER-2: Seeking consumer to 2:10
2021-06-10T16:36:17 [INFO] - WORKER-1: Resetting state with partitions: [1, 0]
2021-06-10T16:36:17 [INFO] - WORKER-1: Seeking consumer to 1:12
2021-06-10T16:36:17 [INFO] - WORKER-1: Seeking consumer to 0:25
2021-06-10T16:36:17 [INFO] - WORKER-2: Conflict offset for partition 3: state=8, delta=10
2021-06-10T16:36:17 [INFO] - WORKER-2: Conflict offset for partition 2: state=9, delta=11
2021-06-10T16:36:17 [INFO] - WORKER-2: Resetting state with partitions: [3, 2]
2021-06-10T16:36:17 [INFO] - WORKER-2: Seeking consumer to 3:11
2021-06-10T16:36:17 [INFO] - WORKER-2: Seeking consumer to 2:12
2021-06-10T16:36:18 [INFO] - WORKER-1: Delta write for version 7 has completed in 601173 microseconds
2021-06-10T16:36:19 [INFO] - WORKER-1: Delta write for version 8 has completed in 718753 microseconds
2021-06-10T16:36:19 [INFO] - WORKER-1: Delta write for version 9 has completed in 653510 microseconds
2021-06-10T16:36:20 [INFO] - WORKER-2: Delta write for version 10 has completed in 2585776 microseconds
2021-06-10T16:36:20 [INFO] - WORKER-1: Delta write for version 11 has completed in 1145232 microseconds
2021-06-10T16:36:21 [INFO] - WORKER-2: Delta write for version 12 has completed in 873619 microseconds
```

So what do we see here. Before, the WORKER-1 had all 4 partition, after introducing the WORKER-2, we've got first to have 0 and 1, second 2 and 3.

On rebalance, we clear all pending state and seek the consumers to the offsets from delta. 

However you might notice that WORKER-2 is seeked twice. That's due to the distributive nature, first seek it to `3:9,2:10`, because delta log versions are `3:8,2:9` (notice +1, because we seek to the next message). But then when WORKER-2 tries to do a commit it founds that the delta store is actually `3:10,2:11` now. That is because of WORKER-1 committed version 6 right in between/before rebalance (note that we first load a table and then subscribe a consumer, so there's a time gap).
But that's okay since WORKER-2 notices that (e.g. updated delta offsets) and seek its consumer to `3:11,2:12`. 
Right after that, WORKER-1 cannot write data to partitions `2,3` so no more conflicts are possible and hence both WORKER-1 and WORKER-2 are making commits to the delta without any conflicts or any other issues in parallel 
