### PR TITLE
Load ssl params from environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,6 +1586,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1"
 log = "0"
 maplit = "1"
 parquet-format = "~2.6.1"
-rdkafka = "0.26"
+rdkafka = { version = "0.26", features = ["ssl"] }
 rusoto_core = { version = "0.46" }
 rusoto_credential = { version = "0.46" }
 rusoto_s3 = { version = "0.46" }

--- a/README.adoc
+++ b/README.adoc
@@ -76,11 +76,28 @@ NOTE: URLs sampled for the test data are sourced from Wikipedia's list of most p
 * Show some parquet data (using link:https://pypi.org/project/parquet-tools/[parquet-tools])
 ** `parquet-tools show tests/data/web_requests/date=2021-03-24/<some file written by your example>`
 
-=== Developing
+== Kafka SSL
+
+In case you have Kafka topics secured by SSL client certificates, you can specify these secrets as environment variables.
+
+For the cert chain include the PEM content as an environment variable named `KAFKA_DELTA_INGEST_CERT`.
+For the cert private key include the PEM content as an environment variable named `KAFKA_DELTA_INGEST_KEY`.
+
+These will be set as the `ssl.certificate.pem` and `ssl.key.pem` Kafka settings respectively.
+
+Make sure to provide the additional option:
+
+```
+-K security.protocol=SSL
+```
+
+when invoking the cli command as well.
+
+== Developing
 
 Make sure the docker-compose test_stack is running, and execute `cargo test` to run unit and integration tests.
 
-=== Get Involved
+== Get Involved
 
 Join link:https://dbricks.co/delta-users-slack[#kafka-delta-ingest in the Delta Lake Slack workspace]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,14 @@ impl KafkaJsonToDelta {
         info!("Kafka broker string is {}", kafka_brokers);
         info!("Kafka consumer group id is {}", consumer_group_id);
 
+        if let Ok(cert_pem) = std::env::var("KAFKA_DELTA_INGEST_CERT") {
+            kafka_client_config.set("ssl.certificate.pem", cert_pem);
+        }
+
+        if let Ok(key_pem) = std::env::var("KAFKA_DELTA_INGEST_KEY") {
+            kafka_client_config.set("ssl.key.pem", key_pem);
+        }
+
         kafka_client_config
             .set("bootstrap.servers", kafka_brokers.clone())
             .set("group.id", consumer_group_id)


### PR DESCRIPTION
This PR adds the ability to load SSL parameters from the environment rather than the command line to avoid log outputs when running in cloud. 

Additionally, it includes the rdkafka ssl feature in Cargo.toml to support SSL at all.