### PR TITLE
Update table schema after file write

### DIFF
--- a/src/deltalake_ext.rs
+++ b/src/deltalake_ext.rs
@@ -127,7 +127,7 @@ impl DeltaArrowWriter {
     /// This method buffers the write stream internally so it can be invoked for many record batches and flushed after the appropriate number of bytes has been written.
     async fn write_record_batch(
         &mut self,
-        partition_columns: &Vec<String>,
+        partition_columns: &[String],
         record_batch: RecordBatch,
     ) -> Result<(), DeltaWriterError> {
         if self.partition_values.is_empty() {
@@ -150,11 +150,10 @@ impl DeltaWriter {
         let storage = deltalake::get_backend_for_uri(table_path)?;
 
         // Initialize an arrow schema ref from the delta table schema
-        let metadata = table.get_metadata()?.clone();
-        let schema = metadata.schema.clone();
-        let arrow_schema = <ArrowSchema as TryFrom<&Schema>>::try_from(&schema).unwrap();
+        let metadata = table.get_metadata()?;
+        let arrow_schema = <ArrowSchema as TryFrom<&Schema>>::try_from(&metadata.schema)?;
         let arrow_schema_ref = Arc::new(arrow_schema);
-        let partition_columns = metadata.partition_columns;
+        let partition_columns = metadata.partition_columns.clone();
 
         // Initialize writer properties for the underlying arrow writer
         let writer_properties = WriterProperties::builder()
@@ -186,6 +185,17 @@ impl DeltaWriter {
     /// Updates the wrapped delta table to load new delta log entries.
     pub async fn update_table(&mut self) -> Result<(), DeltaWriterError> {
         self.table.update().await?;
+        Ok(())
+    }
+
+    pub fn update_schema(&mut self) -> Result<(), DeltaWriterError> {
+        let metadata = self.table.get_metadata()?;
+        let schema = <ArrowSchema as TryFrom<&Schema>>::try_from(&metadata.schema)?;
+        let partition_columns = metadata.partition_columns.clone();
+
+        let _ = std::mem::replace(&mut self.arrow_schema_ref, Arc::new(schema));
+        let _ = std::mem::replace(&mut self.partition_columns, partition_columns);
+
         Ok(())
     }
 
@@ -252,7 +262,7 @@ impl DeltaWriter {
     pub async fn write_parquet_files(&mut self) -> Result<Vec<Add>, DeltaWriterError> {
         debug!("Writing parquet files.");
 
-        let writers = std::mem::replace(&mut self.arrow_writers, HashMap::new());
+        let writers = std::mem::take(&mut self.arrow_writers);
         let mut actions = Vec::new();
 
         for (_, mut writer) in writers {
@@ -278,7 +288,7 @@ impl DeltaWriter {
             debug!("Parquet file {} written.", &storage_path);
 
             // Replace self null_counts with an empty map. Use the other for stats.
-            let null_counts = std::mem::replace(&mut writer.null_counts, HashMap::new());
+            let null_counts = std::mem::take(&mut writer.null_counts);
 
             actions.push(create_add(
                 &writer.partition_values,
@@ -313,7 +323,7 @@ impl DeltaWriter {
     // TODO: parquet files have a 5 digit zero-padded prefix and a "c\d{3}" suffix that I have not been able to find documentation for yet.
     fn next_data_path(
         &self,
-        partition_cols: &Vec<String>,
+        partition_cols: &[String],
         partition_values: &HashMap<String, String>,
     ) -> Result<String, DeltaWriterError> {
         // TODO: what does 00000 mean?
@@ -328,7 +338,7 @@ impl DeltaWriter {
             first_part, uuid_part, last_part
         );
 
-        let data_path = if partition_cols.len() > 0 {
+        let data_path = if !partition_cols.is_empty() {
             let mut path_parts = vec![];
 
             for k in partition_cols.iter() {
@@ -782,7 +792,7 @@ fn create_add(
 }
 
 fn extract_partition_values(
-    partition_cols: &Vec<String>,
+    partition_cols: &[String],
     record_batch: &RecordBatch,
 ) -> Result<HashMap<String, String>, DeltaWriterError> {
     let mut partition_values = HashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,6 +581,9 @@ impl KafkaJsonToDelta {
 
                     self.log_delta_write_completed(version, &delta_write_timer)
                         .await;
+
+                    state.delta_writer.update_schema()?;
+
                     return Ok(());
                 }
                 Err(e) => match e {


### PR DESCRIPTION
This PR adds a method to update the table schema after completing a file write.

Closes #40 