### PR TITLE
Update message schema on the fly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +225,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
@@ -226,9 +250,9 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "os_str_bytes",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.12.1",
  "unicode-width",
  "vec_map",
 ]
@@ -356,7 +380,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "chrono",
- "clap",
+ "clap 3.0.0-beta.2",
  "env_logger",
  "errno",
  "futures",
@@ -859,7 +883,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "chrono",
- "clap",
+ "clap 3.0.0-beta.2",
  "deltalake",
  "dipstick",
  "env_logger",
@@ -1359,11 +1383,13 @@ dependencies = [
  "brotli",
  "byteorder",
  "chrono",
+ "clap 2.33.3",
  "flate2",
  "lz4",
  "num-bigint",
  "parquet-format",
  "rand",
+ "serde_json",
  "snap",
  "thrift",
  "zstd",
@@ -2003,6 +2029,12 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -2063,6 +2095,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,4 @@ parquet = { version = "5" }
 utime = "0.3"
 serial_test = "*"
 tempfile = "3"
-
+parquet  = { version = "5", features = ["cli"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,6 +565,13 @@ impl KafkaJsonToDelta {
                 return Ok(());
             }
 
+            if state.delta_writer.update_schema()? {
+                info!("Transaction attempt failed. Got conflict schema from delta store. Resetting consumer");
+                self.reset_state_guarded(state).await?;
+                // todo delete parquet file
+                return Ok(());
+            }
+
             let version = state.delta_writer.table_version() + 1;
             let commit_result = state
                 .delta_writer

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -14,7 +14,11 @@ use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
 use std::path::Path;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
 use tokio::sync::mpsc::channel;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 pub const TEST_BROKER: &str = "0.0.0.0:9092";
@@ -86,22 +90,14 @@ pub async fn read_files_from_s3(paths: Vec<String>) -> Vec<i32> {
     list
 }
 
-pub fn create_local_table(schema: HashMap<&str, &str>, partitions: Vec<&str>) -> String {
-    let path = format!("./tests/data/gen/table-{}", Uuid::new_v4());
-    let v0 = format!("{}/_delta_log/00000000000000000000.json", &path);
-
-    std::fs::create_dir_all(Path::new(&v0).parent().unwrap()).unwrap();
-
-    let mut file = File::create(v0).unwrap();
+pub fn create_metadata_action_json(schema: &HashMap<&str, &str>, partitions: &[&str]) -> String {
     let mut fields = Vec::new();
-
     for (name, tpe) in schema {
         fields.push(format!(
             r#"{{\"metadata\":{{}},\"name\":\"{}\",\"nullable\":true,\"type\":\"{}\"}}"#,
             name, tpe
         ));
     }
-
     let schema = format!(
         r#"{{\"type\":\"struct\",\"fields\":[{}]}}"#,
         fields.join(",")
@@ -112,13 +108,32 @@ pub fn create_local_table(schema: HashMap<&str, &str>, partitions: Vec<&str>) ->
         .collect::<Vec<String>>()
         .join(",");
 
+    format!(
+        r#"{{"metaData":{{"id":"ec285dbc-6479-4cc1-b038-1de97afabf9b","format":{{"provider":"parquet","options":{{}}}},"schemaString":"{}","partitionColumns":[{}],"configuration":{{}},"createdTime":1621845641001}}}}"#,
+        schema, partitions
+    )
+}
+
+pub fn create_local_table(schema: HashMap<&str, &str>, partitions: Vec<&str>) -> String {
+    let path = format!("./tests/data/gen/table-{}", Uuid::new_v4());
+    let v0 = format!("{}/_delta_log/00000000000000000000.json", &path);
+
+    std::fs::create_dir_all(Path::new(&v0).parent().unwrap()).unwrap();
+
+    let mut file = File::create(v0).unwrap();
+
     writeln!(file, r#"{{"commitInfo":{{"timestamp":1621845641000,"operation":"CREATE TABLE","operationParameters":{{"isManaged":"false","description":null,"partitionBy":"[]","properties":"{{}}"}},"isBlindAppend":true}}}}"#).unwrap();
     writeln!(
         file,
         r#"{{"protocol":{{"minReaderVersion":1,"minWriterVersion":2}}}}"#
     )
     .unwrap();
-    writeln!(file, r#"{{"metaData":{{"id":"ec285dbc-6479-4cc1-b038-1de97afabf9b","format":{{"provider":"parquet","options":{{}}}},"schemaString":"{}","partitionColumns":[{}],"configuration":{{}},"createdTime":1621845641001}}}}"#, schema, partitions).unwrap();
+    writeln!(
+        file,
+        "{}",
+        create_metadata_action_json(&schema, &partitions)
+    )
+    .unwrap();
 
     path
 }
@@ -130,7 +145,7 @@ pub fn create_kdi(
     allowed_latency: u64,
     max_messages_per_batch: usize,
     min_bytes_per_file: usize,
-) -> KafkaJsonToDelta {
+) -> (JoinHandle<()>, Arc<CancellationToken>, Runtime) {
     env::set_var("AWS_S3_LOCKING_PROVIDER", "dynamodb");
     env::set_var("DYNAMO_LOCK_TABLE_NAME", "locks");
     env::set_var("DYNAMO_LOCK_OWNER_NAME", Uuid::new_v4().to_string());
@@ -153,7 +168,7 @@ pub fn create_kdi(
 
     let dummy = channel(1_000_000);
 
-    KafkaJsonToDelta::new(
+    let mut kdi = KafkaJsonToDelta::new(
         opts,
         TEST_BROKER.to_string(),
         format!("{}_{}", app_id, Uuid::new_v4()),
@@ -161,10 +176,19 @@ pub fn create_kdi(
         HashMap::new(),
         dummy.0,
     )
-    .unwrap()
+    .unwrap();
+    let rt = create_runtime(app_id);
+    let token = Arc::new(CancellationToken::new());
+
+    let run_loop = {
+        let token = token.clone();
+        rt.spawn(async move { kdi.start(Some(&token)).await.unwrap() })
+    };
+
+    (run_loop, token, rt)
 }
 
-pub fn create_runtime(name: &str) -> tokio::runtime::Runtime {
+pub fn create_runtime(name: &str) -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
         .thread_name(name)
@@ -193,4 +217,43 @@ pub fn init_logger() {
         })
         .filter(None, log::LevelFilter::Info)
         .try_init();
+}
+
+pub fn wait_until_file_created(path: &Path) {
+    loop {
+        if path.exists() {
+            return;
+        }
+    }
+}
+
+pub fn wait_until_version_created(table: &str, version: i64) {
+    let path = format!("{}/_delta_log/{:020}.json", table, version);
+    wait_until_file_created(Path::new(&path));
+}
+
+pub async fn read_table_content(table_uri: &str) -> Vec<Value> {
+    let table = deltalake::open_table(table_uri).await.unwrap();
+    let backend = deltalake::get_backend_for_uri(&table_uri).unwrap();
+    let tmp = format!(".test-{}.tmp", Uuid::new_v4());
+    let mut list = Vec::new();
+    for file in table.get_file_uris() {
+        let mut bytes = backend.get_obj(&file).await.unwrap();
+        let mut file = File::create(&tmp).unwrap();
+        file.write_all(&mut bytes).unwrap();
+        drop(file);
+        let reader = SerializedFileReader::new(File::open(&tmp).unwrap()).unwrap();
+        let mut row_iter = reader.get_row_iter(None).unwrap();
+
+        while let Some(record) = row_iter.next() {
+            list.push(record.to_json_value());
+        }
+    }
+    std::fs::remove_file(tmp).unwrap();
+
+    list
+}
+
+pub fn commit_file_path(table: &str, version: i64) -> String {
+    format!("{}/_delta_log/{:020}.json", table, version)
 }

--- a/tests/schema_update_tests.rs
+++ b/tests/schema_update_tests.rs
@@ -1,0 +1,126 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::prelude::*;
+use uuid::Uuid;
+
+#[macro_use]
+extern crate maplit;
+
+#[allow(dead_code)]
+mod helpers;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct MsgV1 {
+    id: u32,
+    date: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+struct MsgV2 {
+    id: u32,
+    color: Option<String>,
+    date: String,
+}
+
+#[tokio::test]
+async fn schema_update_test() {
+    helpers::init_logger();
+    let table = helpers::create_local_table(
+        hashmap! {
+            "id" => "integer",
+            "date" => "string",
+        },
+        vec!["date"],
+    );
+    let topic = format!("schema_update_{}", Uuid::new_v4());
+    helpers::create_topic(&topic, 1).await;
+
+    let (kdi, token, rt) = helpers::create_kdi("schema_update", &topic, &table, 5, 1, 20);
+    let producer = helpers::create_producer();
+
+    let msg_v1 = MsgV1 {
+        id: 1,
+        date: "default".to_string(),
+    };
+
+    let msg_v2_1 = MsgV2 {
+        id: 2,
+        color: Some("red".to_string()),
+        date: "default".to_string(),
+    };
+
+    let msg_v2_2 = MsgV2 {
+        id: 3,
+        color: Some("blue".to_string()),
+        date: "default".to_string(),
+    };
+
+    // send msg v1
+    helpers::send_json(
+        &producer,
+        &topic,
+        &serde_json::to_value(msg_v1.clone()).unwrap(),
+    )
+    .await;
+    helpers::wait_until_version_created(&table, 1);
+
+    // update delta schema with new col 'color'
+    let new_schema = hashmap! {
+        "id" => "integer",
+        "color" => "string",
+        "date" => "string",
+    };
+    alter_schema(&table, 2, new_schema, vec!["date"]);
+
+    // send few messages with new schema
+    helpers::send_json(
+        &producer,
+        &topic,
+        &serde_json::to_value(msg_v2_1.clone()).unwrap(),
+    )
+    .await;
+    helpers::send_json(
+        &producer,
+        &topic,
+        &serde_json::to_value(msg_v2_2.clone()).unwrap(),
+    )
+    .await;
+    helpers::wait_until_version_created(&table, 4);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+
+    // retrieve data from the table
+    let content: Vec<MsgV2> = helpers::read_table_content(&table)
+        .await
+        .iter()
+        .map(|v| serde_json::from_value(v.clone()).unwrap())
+        .collect();
+
+    // convert msg v1 to v2
+    let expected = vec![
+        MsgV2 {
+            id: msg_v1.id.clone(),
+            color: None,
+            date: msg_v1.date.clone(),
+        },
+        msg_v2_1,
+        msg_v2_2,
+    ];
+
+    //  and compare the results
+    assert_eq!(content, expected);
+
+    // cleanup
+    for v in 1..=4 {
+        std::fs::remove_file(helpers::commit_file_path(&table, v)).unwrap();
+    }
+}
+
+fn alter_schema(table: &str, version: i64, schema: HashMap<&str, &str>, partitions: Vec<&str>) {
+    let mut file = File::create(format!("{}/_delta_log/{:020}.json", table, version)).unwrap();
+    let schema = helpers::create_metadata_action_json(&schema, &partitions);
+    writeln!(file, "{}", schema).unwrap();
+}


### PR DESCRIPTION
The main challenge is to prevent writing parquet files with outdated schema. This check has to be done before each try to commit (e.g. rename). As the `alter` could happen concurrently, and although the parquet is written with the right schema on that time, the `alter` writer is happen to be more robust on the lock acquiring. 

Once the change is caught, the the commit is rollbacked in a manner as with offset conflict. This means that writer will read data again from the last stored offsets and update the schema accordingly now.