### PR TITLE
Add lag reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "0.4.1"
-source = "git+https://github.com/delta-io/delta-rs.git?branch=writer-map-support#eb0ecf70b59caa70d96fc3afa0c350bdc8aa352d"
+source = "git+https://github.com/delta-io/delta-rs.git?rev=3232743ff8c05bc531c7ebd6393ecdaa24d97ee6#3232743ff8c05bc531c7ebd6393ecdaa24d97ee6"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 arrow  = { git = "https://github.com/apache/arrow-rs", rev = "fa5acd971c973161f17e69d5c6b50d6e77c7da03" }
 parquet = {  git = "https://github.com/apache/arrow-rs", rev = "fa5acd971c973161f17e69d5c6b50d6e77c7da03" }
 
-deltalake = { git = "https://github.com/delta-io/delta-rs.git", branch = "writer-map-support", features = ["s3"] }
+deltalake = { git = "https://github.com/delta-io/delta-rs.git", rev = "3232743ff8c05bc531c7ebd6393ecdaa24d97ee6", features = ["s3"] }
 
 [dev-dependencies]
 utime = "0.3"

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -319,13 +319,37 @@ pub(crate) enum StatTypes {
     //
     // gauges
     //
-    /// Guage for number of Arrow record batches in buffer.
+    /// Gauge for number of Arrow record batches in buffer.
     #[strum(serialize = "buffered.record_batches")]
     BufferedRecordBatches,
-    /// Guage for message size.
+    /// Gauge for message size.
     #[strum(serialize = "messages.size")]
     MessageSize,
-    /// Guage for Delta add file size
+    /// Gauge for Delta add file size.
     #[strum(serialize = "delta.add.size")]
     DeltaAddFileSize,
+    /// Gauge for the number of partitions in buffer.
+    #[strum(serialize = "buffer.lag.num_partitions")]
+    BufferNumPartitions,
+    /// Gauge for total buffer lag across all partitions.
+    #[strum(serialize = "buffer.lag.total")]
+    BufferLagTotal,
+    /// Gauge for max buffer lag across all partitions.
+    #[strum(serialize = "buffer.lag.max")]
+    BufferLagMax,
+    /// Gauge for min buffer lag across all partitions.
+    #[strum(serialize = "buffer.lag.min")]
+    BufferLagMin,
+    /// Gauge for the number of partitions in the last delta write.
+    #[strum(serialize = "delta.write.lag.num_partitions")]
+    DeltaWriteNumPartitions,
+    /// Gauge for total delta write lag across all partitions.
+    #[strum(serialize = "delta.write.lag.total")]
+    DeltaWriteLagTotal,
+    /// Gauge for max delta write lag across all partitions.
+    #[strum(serialize = "delta.write.lag.max")]
+    DeltaWriteLagMax,
+    /// Gauge for min delta write lag across all partitions.
+    #[strum(serialize = "delta.write.lag.min")]
+    DeltaWriteLagMin,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,25 +480,6 @@ impl IngestProcessor {
         let buffer_lags = buffer_lags?;
         let buffer_lags: Vec<i64> = buffer_lags.iter().filter_map(|l| *l).collect();
 
-        // let buffer_lags: Result<Vec<i64>, KafkaError> = state
-        //     .value_buffers
-        //     .buffers
-        //     .iter()
-        //     .map(|(p, b)| {
-        //         let (_, high_watermark) =
-        //             self.consumer
-        //                 .fetch_watermarks(self.topic.as_str(), *p, Timeout::Never)?;
-
-        //         let buffer_lag = if let Some(o) = b.last_offset {
-        //             high_watermark - o
-        //         } else {
-        //             high_watermark
-        //         };
-
-        //         Ok(buffer_lag)
-        //     })
-        //     .collect();
-
         let total_lag: i64 = buffer_lags.iter().sum();
         let max_lag = buffer_lags.iter().max();
         let min_lag = buffer_lags.iter().min();


### PR DESCRIPTION
This PR adds lag reporting to kafka-delta-ingest via statsd metric emissions. 

Two flavors are added - Buffer lag and write lag. Buffer lag represents the last offsets stored in buffer. Write lag represents the last offsets written to the target delta lake table. We report four metrics for each:

* total lag (sum of lag across all partitions handled by the the task/process)
* max (the highest lag observed across all handled partitions)
* min (like max but min)
* number of partitions handled by the task

Buffer lag reports roughly every minute (but requires a message receive to trigger).
Write lag reports every time a write is performed.