### PR TITLE
Handle lag metrics as gauges

### DIFF
--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -202,7 +202,15 @@ impl StatsHandler {
                     // gauges
                     StatTypes::BufferedRecordBatches
                     | StatTypes::MessageSize
-                    | StatTypes::DeltaAddFileSize => {
+                    | StatTypes::DeltaAddFileSize
+                    | StatType::BufferNumPartitions
+                    | StatType::BufferLagTotal
+                    | StatType::BufferLagMax
+                    | StatType::BufferLagMin
+                    | StatType::DeltaWriteNumPartitions
+                    | StatType::DeltaWriteLagTotal
+                    | StatType::DeltaWriteLagMax
+                    | StatType::DeltaWriteLagMin => {
                         self.handle_gauge(stat, val);
                     }
 

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -203,14 +203,14 @@ impl StatsHandler {
                     StatTypes::BufferedRecordBatches
                     | StatTypes::MessageSize
                     | StatTypes::DeltaAddFileSize
-                    | StatType::BufferNumPartitions
-                    | StatType::BufferLagTotal
-                    | StatType::BufferLagMax
-                    | StatType::BufferLagMin
-                    | StatType::DeltaWriteNumPartitions
-                    | StatType::DeltaWriteLagTotal
-                    | StatType::DeltaWriteLagMax
-                    | StatType::DeltaWriteLagMin => {
+                    | StatTypes::BufferNumPartitions
+                    | StatTypes::BufferLagTotal
+                    | StatTypes::BufferLagMax
+                    | StatTypes::BufferLagMin
+                    | StatTypes::DeltaWriteNumPartitions
+                    | StatTypes::DeltaWriteLagTotal
+                    | StatTypes::DeltaWriteLagMax
+                    | StatTypes::DeltaWriteLagMin => {
                         self.handle_gauge(stat, val);
                     }
 


### PR DESCRIPTION
I made an oversight in https://github.com/delta-io/kafka-delta-ingest/pull/77. Lag metrics should be reported as gauges (not counters - which is the default).

This PR corrects that.