### PR TITLE
Write starting offsets as txn actions

### DIFF
--- a/src/starting_offsets.rs
+++ b/src/starting_offsets.rs
@@ -1,0 +1,226 @@
+use crate::delta_helpers::*;
+use crate::{DataTypeOffset, DataTypePartition};
+use deltalake::action::Action;
+use deltalake::{DeltaTable, DeltaTableError};
+use log::{error, info};
+
+/// Errors returned by `write_starting_offsets` function.
+#[derive(thiserror::Error, Debug)]
+pub enum StartingOffsetsError {
+    /// Error returned when stored offsets in delta table are lower than given starting offsets.
+    #[error("Stored offsets are lower than starting: {0}")]
+    InconsistentStoredOffsets(String),
+
+    /// Error from [`deltalake::DeltaTable`]
+    #[error("DeltaTable interaction failed: {source}")]
+    DeltaTable {
+        /// Wrapped [`deltalake::DeltaTableError`]
+        #[from]
+        source: DeltaTableError,
+    },
+}
+
+#[allow(dead_code)]
+pub(crate) async fn write_starting_offsets(
+    table: &mut DeltaTable,
+    app_id: &str,
+    offsets: Vec<(DataTypePartition, DataTypeOffset)>,
+) -> Result<(), StartingOffsetsError> {
+    let offsets_as_str: String = offsets
+        .iter()
+        .map(|(p, o)| format!("{}:{}", p, o))
+        .collect::<Vec<String>>()
+        .join(",");
+
+    info!(
+        "Writing starting offsets [{}] to delta table {}",
+        offsets_as_str, table.table_uri
+    );
+
+    let mapped_offsets: Vec<(String, DataTypeOffset)> = offsets
+        .iter()
+        .map(|(p, o)| (txn_app_id_for_partition(app_id, *p), *o))
+        .collect();
+
+    if is_safe_to_commit_transactions(&table, &mapped_offsets) {
+        // table has no stored offsets for given app_id/partitions so it is safe to write txn actions
+        commit_partition_offsets(table, mapped_offsets, &offsets_as_str).await?;
+        Ok(())
+    } else {
+        // there's at least one app_id/partition stored in delta,
+        // checking whether it's safe to proceed further
+        let mut conflict_offsets = Vec::new();
+
+        for (txn_app_id, offset) in mapped_offsets {
+            match table.get_app_transaction_version().get(&txn_app_id) {
+                Some(stored_offset) if stored_offset < &offset => {
+                    conflict_offsets.push((txn_app_id, *stored_offset, offset));
+                }
+                _ => (),
+            }
+        }
+
+        if conflict_offsets.is_empty() {
+            // there's no conflicted offsets in delta, e.g. is either missing or is higher than starting offset
+            info!(
+                "The starting offsets are already applied for table {}",
+                table.table_uri
+            );
+            Ok(())
+        } else {
+            let partitions = conflict_offsets
+                .iter()
+                .map(|p| p.0.split("-").last().unwrap_or("N/A"))
+                .collect::<Vec<&str>>()
+                .join(",");
+
+            error!("Stored offsets for partitions [{}] are lower than given starting offsets in table {}", partitions, table.table_uri);
+
+            let detailed_error_msg = conflict_offsets
+                .iter()
+                .map(|(partition, stored, starting)| {
+                    format!("{}:stored={}/starting={}", partition, stored, starting)
+                })
+                .collect::<Vec<String>>()
+                .join(", ");
+
+            Err(StartingOffsetsError::InconsistentStoredOffsets(format!(
+                "[{}]",
+                detailed_error_msg
+            )))
+        }
+    }
+}
+
+async fn commit_partition_offsets(
+    table: &mut DeltaTable,
+    offsets: Vec<(String, DataTypeOffset)>,
+    offsets_as_str: &str,
+) -> Result<(), DeltaTableError> {
+    let actions: Vec<Action> = offsets
+        .iter()
+        .map(|(txn_id, offset)| create_txn_action(txn_id.to_string(), *offset))
+        .collect();
+
+    let mut tx = table.create_transaction(None);
+    tx.add_actions(actions);
+    let prepared_commit = tx.prepare_commit(None).await?;
+
+    let mut attempt_number = 0;
+    loop {
+        table.update().await?;
+        let version = table.version + 1;
+
+        if !is_safe_to_commit_transactions(&table, &offsets) {
+            // Partitions offsets have been committed by other writer, nothing to do here now
+            return Ok(());
+        }
+
+        match table
+            .try_commit_transaction(&prepared_commit, version)
+            .await
+        {
+            Ok(v) => {
+                info!(
+                    "Delta version {} completed with starting offsets {}.",
+                    v, offsets_as_str
+                );
+                return Ok(());
+            }
+            Err(e) => match e {
+                DeltaTableError::VersionAlreadyExists(_)
+                    if attempt_number > crate::DEFAULT_DELTA_MAX_RETRY_COMMIT_ATTEMPTS + 1 =>
+                {
+                    error!("Transaction attempt failed. Attempts exhausted beyond max_retry_commit_attempts of {} so failing", crate::DEFAULT_DELTA_MAX_RETRY_COMMIT_ATTEMPTS);
+                    return Err(e.into());
+                }
+                DeltaTableError::VersionAlreadyExists(_) => {
+                    attempt_number += 1;
+                }
+                _ => {
+                    return Err(e);
+                }
+            },
+        }
+    }
+}
+
+fn is_safe_to_commit_transactions(
+    table: &DeltaTable,
+    offsets: &Vec<(String, DataTypeOffset)>,
+) -> bool {
+    offsets
+        .iter()
+        .all(|(id, _)| !table.get_app_transaction_version().contains_key(id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use uuid::Uuid;
+
+    const VERSION_0: &str = r#"{"commitInfo":{"timestamp":1564524295023,"operation":"CREATE TABLE","operationParameters":{"isManaged":"false","description":null,"partitionBy":"[]","properties":"{}"},"isBlindAppend":true}}
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"metaData":{"id":"22ef18ba-191c-4c36-a606-3dad5cdf3830","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1564524294376}}
+"#;
+
+    #[tokio::test]
+    async fn write_starting_offsets_test() {
+        env_logger::init();
+
+        let mut table = create_table().await;
+
+        let offsets = vec![(0, 5), (1, 10)];
+
+        // Test successful write
+        assert_eq!(table.version, 0);
+        write_starting_offsets(&mut table, "test", offsets.clone())
+            .await
+            .unwrap();
+
+        // verify that txn action is written
+        table.update().await.unwrap();
+        assert_eq!(table.version, 1);
+        assert_eq!(
+            table.get_app_transaction_version().get("test-0").unwrap(),
+            &5
+        );
+        assert_eq!(
+            table.get_app_transaction_version().get("test-1").unwrap(),
+            &10
+        );
+
+        // Test ignored write
+        write_starting_offsets(&mut table, "test", offsets)
+            .await
+            .unwrap();
+
+        // verify that txn action is not written
+        table.update().await.unwrap();
+        assert_eq!(table.version, 1);
+
+        // Test failed write (lower stored offsets)
+        let offsets = vec![(0, 15)];
+        let err = write_starting_offsets(&mut table, "test", offsets)
+            .await
+            .err()
+            .unwrap();
+        let err = format!("{:?}", err);
+
+        assert_eq!(
+            err.as_str(),
+            "InconsistentStoredOffsets(\"[test-0:stored=5/starting=15]\")"
+        );
+
+        std::fs::remove_dir_all(table.table_uri).unwrap();
+    }
+
+    async fn create_table() -> DeltaTable {
+        let table_path = format!("./tests/gen/table-{}", Uuid::new_v4());
+        let v0_path = format!("{}/_delta_log/00000000000000000000.json", &table_path);
+        std::fs::create_dir_all(Path::new(&v0_path).parent().unwrap()).unwrap();
+        std::fs::write(&v0_path, VERSION_0).unwrap();
+        deltalake::open_table(&table_path).await.unwrap()
+    }
+}


### PR DESCRIPTION
The current approach with relying on kafka seeks is unreliable since consumer could ingest topics from earliest before the actual seek and as such corrupt the delta store. Just adding the filtering on the consumed offsets/stored offsets as with `txn` actions is not enough since there's more places where it could crash, e.g. the rebalance event with writers reseek and state clearance.

As such, we're moving towards the well tested and bullet proof usage of `txn` actions which are guarded by delta protocol and optimistic concurrency loop with dynamodb locking. 

The introducing changes will write first the delta log version with `txn` actions for each partition that are given by startingOffsets param. This is done only once by the very first succeeding writer. Once this is achieved, then the delta table is protected from duplicates and kafka seek inconsistency by delta protocol.