### PR TITLE
Use hotfix version of delta-rs to address nullable partition values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "0.4.1"
-source = "git+https://github.com/delta-io/delta-rs.git?rev=8d12ad8a8d41060a3175f453249360c70239f633#8d12ad8a8d41060a3175f453249360c70239f633"
+source = "git+https://github.com/delta-io/delta-rs.git?branch=kdi-partition-values-quick-fix#6d63014e1544f8db80625eb7325573eeef1b7a9d"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 arrow  = { git = "https://github.com/apache/arrow-rs", rev = "615d7830fdaf994ebd32ca1e349daf68b18c99b0" }
 parquet = {  git = "https://github.com/apache/arrow-rs", rev = "615d7830fdaf994ebd32ca1e349daf68b18c99b0" }
 
-deltalake = { git = "https://github.com/delta-io/delta-rs.git", rev = "8d12ad8a8d41060a3175f453249360c70239f633", features = ["s3"] }
+deltalake = { git = "https://github.com/delta-io/delta-rs.git", branch = "kdi-partition-values-quick-fix", features = ["s3"] }
 
 # sentry
 sentry = { version = "0.23.0", optional = true }


### PR DESCRIPTION
Using delta-rs `branch = "kdi-partition-values-quick-fix"` which contains latest used commit (rev `8d12ad`) + hotfix 