### PR TITLE
Refactor writer::apply_null_counts to reduce nesting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1119,12 +1119,12 @@ fn kafka_client_config_from_options(opts: &IngestOptions) -> ClientConfig {
 async fn dead_letter_queue_from_options(
     opts: &IngestOptions,
 ) -> Result<Box<dyn DeadLetterQueue>, DeadLetterQueueError> {
-    Ok(dead_letters::dlq_from_opts(DeadLetterQueueOptions {
+    dead_letters::dlq_from_opts(DeadLetterQueueOptions {
         delta_table_uri: opts.dlq_table_uri.clone(),
         dead_letter_transforms: opts.dlq_transforms.clone(),
         write_checkpoints: opts.write_checkpoints,
     })
-    .await?)
+    .await
 }
 
 /// Creates a vec of partition numbers from a topic partition list.

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -311,8 +311,7 @@ fn set_value(object: &mut Map<String, Value>, path: &ValuePath, path_index: usiz
                     object.insert(property.to_string(), value);
                 } else if let Some(next_o) = object
                     .get_mut(property)
-                    .map(|v| v.as_object_mut())
-                    .flatten()
+                    .and_then(|v| v.as_object_mut())
                 {
                     // the next object already exists on the object. recurse.
                     set_value(next_o, path, path_index + 1, value);

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -309,9 +309,8 @@ fn set_value(object: &mut Map<String, Value>, path: &ValuePath, path_index: usiz
                 if path_index == path.len() - 1 {
                     // this is the leaf property - set value on the current object in context.
                     object.insert(property.to_string(), value);
-                } else if let Some(next_o) = object
-                    .get_mut(property)
-                    .and_then(|v| v.as_object_mut())
+                } else if let Some(next_o) =
+                    object.get_mut(property).and_then(|v| v.as_object_mut())
                 {
                     // the next object already exists on the object. recurse.
                     set_value(next_o, path, path_index + 1, value);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -885,27 +885,22 @@ fn min_and_max_from_parquet_statistics(
         DataType::Float32 => {
             let min_array = as_primitive_array::<arrow::datatypes::Float32Type>(&min_array);
             let min = arrow::compute::min(min_array);
-            let min = min
-                .and_then(|f| Number::from_f64(f as f64).map(Value::Number))
-                ;
+            let min = min.and_then(|f| Number::from_f64(f as f64).map(Value::Number));
 
             let max_array = as_primitive_array::<arrow::datatypes::Float32Type>(&max_array);
             let max = arrow::compute::max(max_array);
-            let max = max
-                .and_then(|f| Number::from_f64(f as f64).map(Value::Number));
+            let max = max.and_then(|f| Number::from_f64(f as f64).map(Value::Number));
 
             Ok((min, max))
         }
         DataType::Float64 => {
             let min_array = as_primitive_array::<arrow::datatypes::Float64Type>(&min_array);
             let min = arrow::compute::min(min_array);
-            let min = min
-                .and_then(|f| Number::from_f64(f).map(Value::Number));
+            let min = min.and_then(|f| Number::from_f64(f).map(Value::Number));
 
             let max_array = as_primitive_array::<arrow::datatypes::Float64Type>(&max_array);
             let max = arrow::compute::max(max_array);
-            let max = max
-                .and_then(|f| Number::from_f64(f).map(Value::Number));
+            let max = max.and_then(|f| Number::from_f64(f).map(Value::Number));
 
             Ok((min, max))
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -886,14 +886,13 @@ fn min_and_max_from_parquet_statistics(
             let min_array = as_primitive_array::<arrow::datatypes::Float32Type>(&min_array);
             let min = arrow::compute::min(min_array);
             let min = min
-                .map(|f| Number::from_f64(f as f64).map(Value::Number))
-                .flatten();
+                .and_then(|f| Number::from_f64(f as f64).map(Value::Number))
+                ;
 
             let max_array = as_primitive_array::<arrow::datatypes::Float32Type>(&max_array);
             let max = arrow::compute::max(max_array);
             let max = max
-                .map(|f| Number::from_f64(f as f64).map(Value::Number))
-                .flatten();
+                .and_then(|f| Number::from_f64(f as f64).map(Value::Number));
 
             Ok((min, max))
         }
@@ -901,14 +900,12 @@ fn min_and_max_from_parquet_statistics(
             let min_array = as_primitive_array::<arrow::datatypes::Float64Type>(&min_array);
             let min = arrow::compute::min(min_array);
             let min = min
-                .map(|f| Number::from_f64(f).map(Value::Number))
-                .flatten();
+                .and_then(|f| Number::from_f64(f).map(Value::Number));
 
             let max_array = as_primitive_array::<arrow::datatypes::Float64Type>(&max_array);
             let max = arrow::compute::max(max_array);
             let max = max
-                .map(|f| Number::from_f64(f).map(Value::Number))
-                .flatten();
+                .and_then(|f| Number::from_f64(f).map(Value::Number));
 
             Ok((min, max))
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -676,42 +676,54 @@ fn apply_null_counts(
                 return;
             }
 
-            match column.data_type() {
-                // Recursive case
-                DataType::Struct(_) => {
-                    let col_struct = null_counts
-                        .entry(key)
-                        .or_insert_with(|| ColumnCountStat::Column(HashMap::new()));
-
-                    match col_struct {
-                        ColumnCountStat::Column(map) => {
-                            apply_null_counts(
-                                partition_columns,
-                                as_struct_array(column),
-                                map,
-                                nest_level + 1,
-                            );
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                // Base case
-                _ => {
-                    let col_struct = null_counts
-                        .entry(key.clone())
-                        .or_insert_with(|| ColumnCountStat::Value(0));
-
-                    match col_struct {
-                        ColumnCountStat::Value(n) => {
-                            let null_count = column.null_count() as DeltaDataTypeLong;
-                            let n = null_count + *n;
-                            null_counts.insert(key, ColumnCountStat::Value(n));
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-            }
+            apply_null_counts_for_column(partition_columns, null_counts, nest_level, column, field);
         });
+}
+
+fn apply_null_counts_for_column(
+    partition_columns: &[String],
+    null_counts: &mut HashMap<String, ColumnCountStat>,
+    nest_level: i32,
+    column: &&Arc<dyn Array>,
+    field: &Field,
+) {
+    let key = field.name().to_owned();
+
+    match column.data_type() {
+        // Recursive case
+        DataType::Struct(_) => {
+            let col_struct = null_counts
+                .entry(key)
+                .or_insert_with(|| ColumnCountStat::Column(HashMap::new()));
+
+            match col_struct {
+                ColumnCountStat::Column(map) => {
+                    apply_null_counts(
+                        partition_columns,
+                        as_struct_array(column),
+                        map,
+                        nest_level + 1,
+                    );
+                }
+                _ => unreachable!(),
+            }
+        }
+        // Base case
+        _ => {
+            let col_struct = null_counts
+                .entry(key.clone())
+                .or_insert_with(|| ColumnCountStat::Value(0));
+
+            match col_struct {
+                ColumnCountStat::Value(n) => {
+                    let null_count = column.null_count() as DeltaDataTypeLong;
+                    let n = null_count + *n;
+                    null_counts.insert(key, ColumnCountStat::Value(n));
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
 }
 
 fn apply_min_max_for_column(


### PR DESCRIPTION
This PR contains a small code cleanup of `writer::apply_null_counts` to reduce nesting and improve readability.

@thovoll and I paired on this together (**FUN!**) as part of what will hopefully become a semi-regular code cleanup pairing session. We noted that there is some potential for additional cleanup in these two functions, but just this small change as-is represents a worthwhile well-scoped and safe incremental improvement.
