### PR TITLE
Add a Timeout future to allow flush to happen without a message

### DIFF
--- a/tests/buffer_flush_tests.rs
+++ b/tests/buffer_flush_tests.rs
@@ -1,0 +1,152 @@
+#[allow(dead_code)]
+mod helpers;
+
+use deltalake;
+use log::info;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::time::{sleep, Duration};
+
+use kafka_delta_ingest::IngestOptions;
+
+#[tokio::test]
+async fn test_flush_when_latency_expires() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+            "flush_when_latency_expires",
+            json!({
+                "id": "integer",
+                "date": "string",
+            }),
+            vec!["date"],
+            1,
+            Some(IngestOptions {
+                app_id: "flush_when_latency_expires".to_string(),
+                // buffer for 5 seconds before flush
+                allowed_latency: 5,
+                // large value - avoid flushing on num messages
+                max_messages_per_batch: 5000,
+                // large value - avoid flushing on file size
+                min_bytes_per_file: 1000000,
+                ..Default::default()
+            })
+        ).await;
+
+    for m in create_generator(1).take(10) {
+        info!("Writing test message");
+        helpers::send_json(&producer, &topic, &serde_json::to_value(m).unwrap()).await;
+    }
+
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 1);
+
+    for m in create_generator(11).take(10) {
+        info!("Writing test message");
+        helpers::send_json(&producer, &topic, &serde_json::to_value(m).unwrap()).await;
+    }
+
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 2);
+
+    let v1_rows: Vec<TestMsg> = helpers::read_table_content_at_version_as(&table, 1).await;
+    let v2_rows: Vec<TestMsg> = helpers::read_table_content_as(&table).await;
+
+    assert_eq!(v1_rows.len(), 10);
+    assert_eq!(v2_rows.len(), 20);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[tokio::test]
+async fn test_dont_write_an_empty_buffer() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+            "dont_write_an_empty_buffer",
+            json!({
+                "id": "integer",
+                "date": "string",
+            }),
+            vec!["date"],
+            1,
+            Some(IngestOptions {
+                app_id: "dont_write_an_empty_buffer".to_string(),
+                // buffer for 5 seconds before flush
+                allowed_latency: 5,
+                ..Default::default()
+            })
+        ).await;
+    // write one version so we can make sure the stream is up and running.
+
+    for m in create_generator(1).take(10) {
+        info!("Writing test message");
+        helpers::send_json(&producer, &topic, &serde_json::to_value(m).unwrap()).await;
+    }
+
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 1);
+
+    // wait for the latency timer to trigger
+    sleep(Duration::from_secs(6)).await;
+
+    // verify that an empty version _was not_ created.
+    // i.e. we should still be at version 1
+    
+    let t = deltalake::open_table(&table).await.unwrap();
+
+    assert_eq!(1, t.version);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[tokio::test]
+async fn test_flush_on_size_without_latency_expiration() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+            "flush_on_size_without_latency_expiration",
+            json!({
+                "id": "integer",
+                "date": "string",
+            }),
+            vec!["date"],
+            1,
+            Some(IngestOptions {
+                app_id: "flush_on_size_without_latency_expiration".to_string(),
+                // buffer for an hour
+                allowed_latency: 3600,
+                // create a record batch when we have 10 messages
+                max_messages_per_batch: 10,
+                // tiny buffer size for write flush
+                min_bytes_per_file: 20,
+                ..Default::default()
+            })
+        ).await;
+
+    for m in create_generator(1).take(10) {
+        info!("Writing test message");
+        helpers::send_json(&producer, &topic, &serde_json::to_value(m).unwrap()).await;
+    }
+
+    helpers::wait_until_version_created(&table, 1);
+
+    let data: Vec<TestMsg> = helpers::read_table_content_at_version_as(&table, 1).await;
+
+    assert_eq!(data.len(), 10);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+struct TestMsg {
+    id: u64,
+    date: String,
+}
+
+fn create_generator(staring_id: u64) -> impl Iterator<Item = TestMsg> {
+    std::iter::successors(Some(staring_id), |n| Some(*n + 1)).map(|n| TestMsg {
+        id: n,
+        date: "2022-06-03".to_string()
+    })
+}

--- a/tests/dead_letter_tests.rs
+++ b/tests/dead_letter_tests.rs
@@ -87,7 +87,7 @@ async fn test_dlq() {
 
     info!("Waiting for version 1 of dlq table");
     helpers::wait_until_version_created(&dlq_table, 1);
-    info!("Waiting for version 2 of data table");
+    info!("Waiting for version 1 of data table");
     helpers::wait_until_version_created(&table, 1);
 
     // 1 message with bad bytes

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,5 +1,6 @@
 use chrono::Local;
 use deltalake::action::{Action, Add, MetaData, Protocol, Remove, Txn};
+use deltalake::{DeltaDataTypeVersion, DeltaTable, StorageBackend};
 use kafka_delta_ingest::{start_ingest, IngestOptions};
 use parquet::util::cursor::SliceableCursor;
 use parquet::{
@@ -337,9 +338,29 @@ pub async fn read_table_content_as<T: DeserializeOwned>(table_uri: &str) -> Vec<
         .collect()
 }
 
+pub async fn read_table_content_at_version_as<T: DeserializeOwned>(table_uri: &str, version: DeltaDataTypeVersion) -> Vec<T> {
+    read_table_content_at_version_as_jsons(table_uri, version)
+        .await
+        .iter()
+        .map(|v| serde_json::from_value(v.clone()).unwrap())
+        .collect()
+}
+
 pub async fn read_table_content_as_jsons(table_uri: &str) -> Vec<Value> {
     let table = deltalake::open_table(table_uri).await.unwrap();
     let backend = deltalake::get_backend_for_uri(&table_uri).unwrap();
+
+    json_listify_table_content(table, backend).await
+}
+
+pub async fn read_table_content_at_version_as_jsons(table_uri: &str, version: DeltaDataTypeVersion) -> Vec<Value> {
+    let table = deltalake::open_table_with_version(table_uri, version).await.unwrap();
+    let backend = deltalake::get_backend_for_uri(&table_uri).unwrap();
+
+    json_listify_table_content(table, backend).await
+}
+
+async fn json_listify_table_content(table: DeltaTable, backend: Box<dyn StorageBackend>) -> Vec<Value> {
     let tmp = format!(".test-{}.tmp", Uuid::new_v4());
     let mut list = Vec::new();
     for file in table.get_file_uris() {

--- a/tests/playground.rs
+++ b/tests/playground.rs
@@ -73,7 +73,7 @@ impl Playground {
         helpers::create_topic(&topic, 1).await;
 
         let ingest_options = IngestOptions {
-            app_id: "schema_update".to_string(),
+            app_id: "playground".to_string(),
             allowed_latency: 5,
             max_messages_per_batch: MAX_MESSAGES_PER_BATCH,
             min_bytes_per_file: 20,


### PR DESCRIPTION
This PR addresses https://github.com/delta-io/kafka-delta-ingest/issues/74, but by using a timeout future instead of the approaches described in the issue. 🙇 to @houqp for pointing me to [Timeout](https://docs.rs/tokio/latest/tokio/time/struct.Timeout.html) struct.

From the original issue:

> Kafka delta ingest currently requires a message to trigger the latency timer check for flushing buffers. It would be better if we ran the latency timer on a separate thread to trigger flushes - especially for low volume topics that receive periodic writes. For these low volume topics that are triggered periodically - we suck everything in from Kafka and it just sits in buffer until we get another message.

I've changed the [run loop](https://github.com/delta-io/kafka-delta-ingest/compare/main...xianwill:latency-flush-timer#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R339) to be an infinite `loop` and [wrapped](https://github.com/delta-io/kafka-delta-ingest/compare/main...xianwill:latency-flush-timer#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R342) the invocation of `consumer.stream().next()` with an invocation of `tokio::time::timeout`. 

The [consume_timeout_duration](https://github.com/delta-io/kafka-delta-ingest/compare/main...xianwill:latency-flush-timer#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R641-R653) method of `IngestProcessor` returns the appropriate timeout duration for each iteration of the run loop based on how much time has elapsed since the latency timer was started.

I addressed another issue related to the latency timer (not documented in the original issue), where the first message received after startup may trigger a write of a single row. This happens because the latency timer is initialized before the Kafka stream is fully initialized. I've [added logic](https://github.com/delta-io/kafka-delta-ingest/compare/main...xianwill:latency-flush-timer#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R373-R375) to re-initialize the latency timer after consuming the first message.

The PR also contains a couple of tiny drive-bys as well:

* Fix the `app_id` in the [playground test](https://github.com/delta-io/kafka-delta-ingest/compare/main...xianwill:latency-flush-timer#diff-0f4615c230356c98ac3e1a8da4d5e590dc034b8950b6ec6ed433505064c5b06dR76)
* Fix a log message in the [dead letter test](https://github.com/delta-io/kafka-delta-ingest/compare/main...xianwill:latency-flush-timer#diff-e8cf8d457b24cc44866e807e66be1f2a297b8d6e318776a2176dfa99ead65f7fR90)



After merge, I plan to start a branch to reverse integrate this into https://github.com/delta-io/kafka-delta-ingest/pull/114 and fix some flaky test problems @thovoll and I have seen on that PR. The latency timer fixes should make some of those flaky tests easier to troubleshoot since we won't have to do weird things like send bad messages to trigger a flush anymore.


