### PR TITLE
Demonstrate a bug for schema "validation" when writing JSON to a table

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1056,6 +1056,56 @@ mod tests {
     use std::path::Path;
 
     #[tokio::test]
+    async fn test_schema_matching() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let table_path = temp_dir.path();
+        create_temp_table(table_path);
+
+        let table = crate::delta_helpers::load_table(table_path.to_str().unwrap(), HashMap::new())
+            .await
+            .unwrap();
+        let mut writer = DataWriter::for_table(&table, HashMap::new()).unwrap();
+        let rows: Vec<Value> = vec![json!({
+            "meta": {
+                "kafka": {
+                    "offset": 0,
+                    "partition": 0,
+                    "topic": "some_topic"
+                },
+                "producer": {
+                    "timestamp": "2021-06-22"
+                },
+            },
+            "twitch": "is the best",
+            "why" : "does this succeed?!",
+            // If `some_nested_list` is removed, the Decoder ends up outputing
+            // an error that gets interpreted as an EmptyRecordBatch
+            "some_nested_list": [[42], [84]],
+            "date": "2021-06-22"
+        })];
+        let result = writer.write(rows).await;
+        assert!(
+            result.is_err(),
+            "Expected the write of our invalid schema rows to fail!\n{:?}",
+            result
+        );
+        match result {
+            Ok(_) => unreachable!(),
+            Err(DataWriterError::SchemaMismatch {
+                record_batch_schema: _,
+                expected_schema: _,
+            }) => {}
+            Err(e) => {
+                assert!(
+                    false,
+                    "I was expecting a schema mismatch, got this instead: {:?}",
+                    e
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn delta_stats_test() {
         let temp_dir = tempfile::tempdir().unwrap();
         let table_path = temp_dir.path();


### PR DESCRIPTION
I stumbled into this while pilfering code from kafka-delta-ingest for another project and discovered that the code in `write_values` which does `record_batch.schema() != arrow_schema` doesn't do what we think it does.

Basically if `Decoder` "works" the schema it's going to return is just the schema passed into it. It has no bearing on whether the JSON has the same schema. Don't ask me why.

Using the reader's `infer_json_schema_*` functions can provide a Schema that is useful for comparison:

        let mut value_iter = json_buffer.iter().map(|j| Ok(j.to_owned()));
        let json_schema = infer_json_schema_from_iterator(value_iter.clone()).expect("Failed to infer!");
        let decoder = Decoder::new(Arc::new(json_schema), options);
        if let Some(batch) = decoder.next_batch(&mut value_iter).expect("Failed to create RecordBatch") {
            assert_eq!(batch.schema(), arrow_schema_ref, "Schemas don't match!");
        }

What's even more interesting, is that after a certain number of fields are removed, the Decoder no longer pretends it can Decode the JSON. I am baffled as to why.


The current failure from this test is:

```
---- writer::tests::test_schema_matching stdout ----
thread 'writer::tests::test_schema_matching' panicked at 'Expected the write of our invalid schema rows to fail!
Ok(())', src/writer.rs:1089:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```