### PR TITLE
Avro and Schema Registry Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /target
 
 tests/json/*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
 
 [[package]]
+name = "addr"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936697e9caf938eb2905036100edf8e1269da8291f8a02f5fe7b37073784eec0"
+dependencies = [
+ "no-std-net",
+ "psl",
+ "psl-types",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +33,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
@@ -123,6 +140,31 @@ name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
+name = "apache-avro"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf4144857f9e4d7dd6cc4ba4c78efd2a46bad682b029bd0d91e76a021af1b2a"
+dependencies = [
+ "byteorder",
+ "digest 0.10.6",
+ "lazy_static",
+ "libflate",
+ "log",
+ "num-bigint",
+ "quad-rand",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "thiserror",
+ "typed-builder",
+ "uuid 1.3.2",
+ "zerocopy",
+]
 
 [[package]]
 name = "arrow"
@@ -1904,10 +1946,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-pointer"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe841b94e719a482213cee19dd04927cf412f26d8dc84c5a446c081e49c2997"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "jsonway"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effcb749443c905fbaef49d214f8b1049c240e0adb7af9baa0e201e625e4f9de"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kafka-delta-ingest"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "apache-avro",
  "async-trait",
  "azure_core",
  "azure_storage",
@@ -1925,16 +1987,18 @@ dependencies = [
  "lazy_static",
  "log",
  "maplit",
+ "protofish",
  "rdkafka",
  "rusoto_core 0.46.0",
  "rusoto_credential 0.46.0",
  "rusoto_s3",
+ "schema_registry_converter",
  "sentry",
  "serde",
  "serde_json",
  "serial_test",
- "strum",
- "strum_macros",
+ "strum 0.20.0",
+ "strum_macros 0.20.1",
  "tempfile",
  "thiserror",
  "time 0.3.21",
@@ -2021,6 +2085,26 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "libflate"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
+dependencies = [
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libm"
@@ -2196,6 +2280,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "no-std-net"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bcece43b12349917e096cddfa66107277f123e6c96a5aea78711dc601a47152"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2381,7 +2474,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.7.4",
  "tokio",
  "tracing",
  "url",
@@ -2570,6 +2663,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "pest"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.6",
+]
+
+[[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2814,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "protofish"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a5fc771504e21bfc00513bfdb1f8d2c183bdb58a50c8ec31db946daa5a3257"
+dependencies = [
+ "bytes",
+ "pest",
+ "pest_derive",
+ "snafu 0.6.10",
+]
+
+[[package]]
+name = "psl"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1be0afcd844b15cfce18bf8cccf2dfa887a00a6454a9ea135f122b948cee91"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "quad-rand"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
+
+[[package]]
 name = "quick-xml"
 version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,6 +2876,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
+ "rand_pcg",
 ]
 
 [[package]]
@@ -2724,6 +2933,15 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
 ]
@@ -2874,6 +3092,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rusoto_core"
@@ -3151,6 +3375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3172,6 +3402,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "schema_registry_converter"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea1c251bea837ece3126074d9e01c5868e5ae6135946404ceb20b5b2e264f7c"
+dependencies = [
+ "apache-avro",
+ "byteorder",
+ "dashmap",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "valico",
 ]
 
 [[package]]
@@ -3483,6 +3731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,12 +3762,33 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snafu"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+dependencies = [
+ "doc-comment",
+ "snafu-derive 0.6.10",
+]
+
+[[package]]
+name = "snafu"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
 dependencies = [
  "doc-comment",
- "snafu-derive",
+ "snafu-derive 0.7.4",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3627,6 +3902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
 name = "strum_macros"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,6 +3916,19 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn 1.0.109",
 ]
 
@@ -4017,10 +4311,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uname"
@@ -4063,6 +4374,15 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "uritemplate-next"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcde98d1fc3f528255b1ecb22fb688ee0d23deb672a8c57127df10b98b4bd18c"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "url"
@@ -4116,6 +4436,28 @@ checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 dependencies = [
  "getrandom 0.2.9",
  "serde",
+]
+
+[[package]]
+name = "valico"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647856408e327686b6640397d19f60fac3e64c3bfaa6afc409da63ef7da45edb"
+dependencies = [
+ "addr",
+ "base64 0.13.1",
+ "chrono",
+ "json-pointer",
+ "jsonway",
+ "percent-encoding",
+ "phf",
+ "phf_codegen",
+ "regex",
+ "serde",
+ "serde_json",
+ "uritemplate-next",
+ "url",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -4514,6 +4856,27 @@ name = "xmlparser"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,7 +1987,6 @@ dependencies = [
  "lazy_static",
  "log",
  "maplit",
- "protofish",
  "rdkafka",
  "rusoto_core 0.46.0",
  "rusoto_credential 0.46.0",
@@ -2474,7 +2473,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "snafu 0.7.4",
+ "snafu",
  "tokio",
  "tracing",
  "url",
@@ -2663,50 +2662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "pest"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
-dependencies = [
- "once_cell",
- "pest",
- "sha2 0.10.6",
-]
-
-[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,18 +2766,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "protofish"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a5fc771504e21bfc00513bfdb1f8d2c183bdb58a50c8ec31db946daa5a3257"
-dependencies = [
- "bytes",
- "pest",
- "pest_derive",
- "snafu 0.6.10",
 ]
 
 [[package]]
@@ -3762,33 +3705,12 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snafu"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
-dependencies = [
- "doc-comment",
- "snafu-derive 0.6.10",
-]
-
-[[package]]
-name = "snafu"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
 dependencies = [
  "doc-comment",
- "snafu-derive 0.7.4",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "snafu-derive",
 ]
 
 [[package]]
@@ -4326,12 +4248,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uname"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+apache-avro = "^0.14"
 base64 = "0.13"
 bytes = "1"
 chrono = "0"
@@ -18,10 +19,12 @@ jmespatch = { version = "0.3", features = ["sync"] }
 lazy_static = "1"
 log = "0"
 maplit = "1"
+protofish = "^0.5"
 rdkafka = { version = "0.28", features = ["ssl-vendored"] }
 rusoto_core = { version = "0.46" }
 rusoto_credential = { version = "0.46" }
 rusoto_s3 = { version = "0.46" }
+schema_registry_converter = { version = "3.1.0", features = ["easy", "json", "avro", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,11 @@ jmespatch = { version = "0.3", features = ["sync"] }
 lazy_static = "1"
 log = "0"
 maplit = "1"
-protofish = "^0.5"
 rdkafka = { version = "0.28", features = ["ssl-vendored"] }
 rusoto_core = { version = "0.46" }
 rusoto_credential = { version = "0.46" }
 rusoto_s3 = { version = "0.46" }
-schema_registry_converter = { version = "3.1.0", features = ["easy", "json", "avro", "blocking"] }
+schema_registry_converter = { version = "3.1.0", features = ["easy", "json", "avro"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = "0.20"

--- a/README.adoc
+++ b/README.adoc
@@ -258,6 +258,8 @@ aws dynamodb create-table --table-name delta_rs_lock_table \
 == Schema Support
 This application has support for both avro and json format via command line arguments. If no format argument is provided, the default behavior is to use json.
 The table below indicates what will happen with respect to the provided arguments.
+
+|===
 | Argument      | Value |  Result |
 | ----------- | ----------- | ----------- |
 | <none>      | <none>       | default json behavior |

--- a/README.adoc
+++ b/README.adoc
@@ -268,6 +268,7 @@ The table below indicates what will happen with respect to the provided argument
 | --avro   | ""        | expects all messages in avro format |
 | --avro      | <path to an avro schema>       | will use the provided avro schema for deserialization |
 | --avro   | <schema registry url>        | will connect schema registry to deserialize avro |
+|===
 
 
 For more information, see link:https://github.com/delta-io/delta-rs/tree/dbc2994c5fddfd39fc31a8f9202df74788f59a01/dynamodb_lock[DynamoDB lock].

--- a/README.adoc
+++ b/README.adoc
@@ -255,8 +255,21 @@ aws dynamodb create-table --table-name delta_rs_lock_table \
         ReadCapacityUnits=10,WriteCapacityUnits=10
 ```
 
+== Schema Support
+This application has support for both avro and json format via command line arguments. If no format argument is provided, the default behavior is to use json.
+The table below indicates what will happen with respect to the provided arguments.
+| Argument      | Value |  Result |
+| ----------- | ----------- | ----------- |
+| <none>      | <none>       | default json behavior |
+| --json      | <any string>       | default json behavior |
+| --json      | <schema registry url>       |  will connect schema registry to deserialize json |
+| --avro   | ""        | expects all messages in avro format |
+| --avro      | <path to an avro schema>       | will use the provided avro schema for deserialization |
+| --avro   | <schema registry url>        | will connect schema registry to deserialize avro |
+
+
 For more information, see link:https://github.com/delta-io/delta-rs/tree/dbc2994c5fddfd39fc31a8f9202df74788f59a01/dynamodb_lock[DynamoDB lock].
-==== Verifying data in Azure Storage
+== Verifying data in Azure Storage
 
 Use the Azure Portal to browse the file system:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
         aliases:
           - redpanda
     ports:
-      #      - 8081:8081
       - 8082:8082
       - 9092:9092
       - 28082:28082

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,36 +2,52 @@
 version: '3.9'
 services:
   kafka:
-    image: confluentinc/cp-kafka:latest
-    depends_on: 
-      - zookeeper
+    image: docker.redpanda.com/redpandadata/redpanda:v23.1.13
+    command:
+      - redpanda
+      - start
+      - --smp
+      - '1'
+      - --reserve-memory
+      - 0M
+      - --overprovisioned
+      - --node-id
+      - '0'
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
+      - --pandaproxy-addr
+      - PLAINTEXT://0.0.0.0:28082,OUTSIDE://0.0.0.0:8082
+      - --advertise-pandaproxy-addr
+      - PLAINTEXT://redpanda:28082,OUTSIDE://localhost:8082
+    networks:
+      default:
+        aliases:
+          - redpanda
     ports:
-      - "9092:9092"
-    environment:
-      ALLOW_PLAINTEXT_LISTENER: "true"
-      KAFKA_BROKER_ID: "1"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_CREATE_TOPICS: "example:3:1,web_requests:3:1"
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-    healthcheck:
-      test: ["CMD", "bash", "-c", "unset", "JMX_PORT", ";", "kafka-topics.sh", "--zookeeper", "zookeeper:2181", "--list"]
+      #      - 8081:8081
+      - 8082:8082
+      - 9092:9092
+      - 28082:28082
+      - 29092:29092
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:latest
-    environment:
-      ZOOKEEPER_CLIENT_PORT: "2181"
-    privileged: true
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.4.0
+    hostname: schema-registry
+    container_name: schema-registry
+    depends_on:
+      - kafka
     ports:
-      - "2181:2181"
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'redpanda:29092'
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   localstack:
     image: localstack/localstack:0.13.1
-    ports: 
+    ports:
       - "4566:4566"
     environment:
       - SERVICES=s3,dynamodb
@@ -44,16 +60,17 @@ services:
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite
     ports:
-    - "10000:10000"
-    - "10001:10001"
+      - "10000:10000"
+      - "10001:10001"
   setup:
     build:
       context: .
       dockerfile: Dockerfile.setup
-    depends_on: 
+    depends_on:
       - kafka
       - localstack
       - azurite
+      - schema-registry
     entrypoint: "/bin/bash"
     command:
       - /localstack-setup_emails.sh

--- a/src/dead_letters.rs
+++ b/src/dead_letters.rs
@@ -38,12 +38,12 @@ pub struct DeadLetter {
 impl DeadLetter {
     /// Creates a dead letter from bytes that failed deserialization.
     /// `json_string` will always be `None`.
-    pub(crate) fn from_failed_deserialization(bytes: &[u8], err: serde_json::Error) -> Self {
+    pub(crate) fn from_failed_deserialization(bytes: &[u8], err: String) -> Self {
         let timestamp = Utc::now();
         Self {
             base64_bytes: Some(base64::encode(bytes)),
             json_string: None,
-            error: Some(err.to_string()),
+            error: Some(err),
             timestamp: timestamp.timestamp_nanos() / 1000,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,12 @@ use rdkafka::{
 };
 use serde_json::Value;
 use serialization::{MessageDeserializer, MessageDeserializerFactory};
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::{collections::HashMap, path::PathBuf};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
+use url::Url;
 
 mod coercions;
 /// Doc
@@ -231,10 +232,10 @@ pub enum SchemaSource {
     None,
 
     /// Use confluent schema registry url
-    SchemaRegistry(String),
+    SchemaRegistry(Url),
 
     /// Use provided file for schema
-    File(String),
+    File(PathBuf),
 }
 
 /// The enum to represent 'auto.offset.reset' options.
@@ -624,8 +625,6 @@ enum MessageDeserializationError {
     JsonDeserialization { dead_letter: DeadLetter },
     #[error("Kafka message deserialization failed")]
     AvroDeserialization { dead_letter: DeadLetter },
-    //    #[error("Kafka message deserialization failed")]
-    //    ProtoDeserialization { dead_letter: DeadLetter },
 }
 
 /// Indicates whether a rebalance signal should simply skip the currently consumed message, or clear state and skip.
@@ -754,7 +753,6 @@ impl IngestProcessor {
             Err(
                 MessageDeserializationError::JsonDeserialization { dead_letter }
                 | MessageDeserializationError::AvroDeserialization { dead_letter },
-                // | MessageDeserializationError::ProtoDeserialization { dead_letter },
             ) => {
                 warn!(
                     "Deserialization failed - partition {}, offset {}, dead_letter {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,6 @@ pub enum MessageFormat {
 
     /// Parses avro messages using provided schema, schema registry or schema within file
     Avro(SchemaSource),
-    //    ProtoBuf(SchemaSource),
 }
 
 /// Source for schema

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,7 +787,7 @@ impl IngestProcessor {
         let value = self.message_deserializer.deserialize(message_bytes).await?;
         self.ingest_metrics
             .message_deserialized_size(message_bytes.len());
-        return Ok(value);
+        Ok(value)
     }
 
     /// Writes the transformed messages currently held in buffer to parquet byte buffers.

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ fn to_schema_source(input: Option<&String>, disable_files: bool) -> SchemaSource
                 return SchemaSource::File(schema_source_value);
             }
 
-            return SchemaSource::SchemaRegistry(schema_source_value);
+            SchemaSource::SchemaRegistry(schema_source_value)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,7 +427,7 @@ mod test {
 
     use crate::{build_app, convert_matches_to_message_format, parse_seek_offsets};
 
-    static SCHEMA_REGISTRY_ADDRESS: &'static str = "http://localhost:8081";
+    const SCHEMA_REGISTRY_ADDRESS: &str = "http://localhost:8081";
 
     #[test]
     fn parse_seek_offsets_test() {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,282 @@
+use std::{borrow::BorrowMut, convert::TryFrom, io::Cursor};
+
+use async_trait::async_trait;
+use schema_registry_converter::async_impl::{
+    easy_avro::EasyAvroDecoder, easy_json::EasyJsonDecoder, schema_registry::SrSettings,
+};
+use serde_json::Value;
+
+use crate::{dead_letters::DeadLetter, MessageDeserializationError, MessageFormat};
+
+#[async_trait]
+pub(crate) trait MessageDeserializer {
+    async fn deserialize(
+        &mut self,
+        message_bytes: &[u8],
+    ) -> Result<Value, MessageDeserializationError>;
+}
+
+pub(crate) struct MessageDeserializerFactory {}
+impl MessageDeserializerFactory {
+    pub fn try_build(
+        input_format: &MessageFormat,
+    ) -> Result<Box<dyn MessageDeserializer + Send>, anyhow::Error> {
+        match input_format {
+            MessageFormat::Json(data) => match data {
+                crate::SchemaSource::None => Ok(Self::json_default()),
+                crate::SchemaSource::SchemaRegistry(sr) => {
+                    match Self::build_sr_settings((*sr).clone())
+                        .map(|sr_settings| JsonDeserializer::from_schema_registry(sr_settings))
+                    {
+                        Ok(s) => Ok(Box::new(s)),
+                        Err(e) => Err(e),
+                    }
+                }
+                crate::SchemaSource::File(_) => Ok(Self::json_default()),
+            },
+            MessageFormat::Avro(data) => match data {
+                crate::SchemaSource::None => Ok(Box::new(AvroSchemaDeserializer::default())),
+                crate::SchemaSource::SchemaRegistry(sr) => {
+                    match Self::build_sr_settings((*sr).clone())
+                        .map(|sr_settings| AvroDeserializer::from_schema_registry(sr_settings))
+                    {
+                        Ok(s) => Ok(Box::new(s)),
+                        Err(e) => Err(e),
+                    }
+                }
+                crate::SchemaSource::File(f) => {
+                    match AvroSchemaDeserializer::try_from_schema_file(f) {
+                        Ok(s) => Ok(Box::new(s)),
+                        Err(e) => Err(e),
+                    }
+                }
+            },
+            _ => Ok(Box::new(DefaultDeserializer {})),
+        }
+    }
+
+    fn json_default() -> Box<dyn MessageDeserializer + Send> {
+        Box::new(DefaultDeserializer {})
+    }
+
+    fn build_sr_settings(registry_url: String) -> Result<SrSettings, anyhow::Error> {
+        let mut builder = SrSettings::new_builder(registry_url);
+        if let Ok(username) = std::env::var("SCHEMA_REGISTRY_USERNAME") {
+            builder.set_basic_authorization(
+                username.as_str(),
+                std::option_env!("SCHEMA_REGISTRY_PASSWORD"),
+            );
+        }
+
+        if let Ok(proxy_url) = std::env::var("SCHEMA_REGISTRY_PROXY") {
+            builder.set_proxy(proxy_url.as_str());
+        }
+
+        match builder.build() {
+            Ok(s) => Ok(s),
+            Err(e) => Err(anyhow::Error::new(e)),
+        }
+    }
+}
+
+struct DefaultDeserializer {}
+
+#[async_trait]
+impl MessageDeserializer for DefaultDeserializer {
+    async fn deserialize(&mut self, payload: &[u8]) -> Result<Value, MessageDeserializationError> {
+        let value: Value = match serde_json::from_slice(payload) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(MessageDeserializationError::JsonDeserialization {
+                    dead_letter: DeadLetter::from_failed_deserialization(payload, e.to_string()),
+                });
+            }
+        };
+
+        Ok(value)
+    }
+}
+
+struct AvroDeserializer {
+    decoder: EasyAvroDecoder,
+}
+
+struct AvroSchemaDeserializer {
+    schema: Option<apache_avro::Schema>,
+}
+
+struct JsonDeserializer {
+    decoder: EasyJsonDecoder,
+}
+
+#[async_trait]
+impl MessageDeserializer for AvroDeserializer {
+    async fn deserialize(
+        &mut self,
+        message_bytes: &[u8],
+    ) -> Result<Value, MessageDeserializationError> {
+        match self.decoder.decode_with_schema(Some(message_bytes)).await {
+            Ok(drs) => match drs {
+                Some(v) => match Value::try_from(v.value) {
+                    Ok(v) => Ok(v),
+                    Err(e) => Err(MessageDeserializationError::AvroDeserialization {
+                        dead_letter: DeadLetter::from_failed_deserialization(
+                            message_bytes,
+                            e.to_string(),
+                        ),
+                    }),
+                },
+                None => return Err(MessageDeserializationError::EmptyPayload),
+            },
+            Err(e) => {
+                return Err(MessageDeserializationError::AvroDeserialization {
+                    dead_letter: DeadLetter::from_failed_deserialization(
+                        message_bytes,
+                        e.to_string(),
+                    ),
+                });
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl MessageDeserializer for AvroSchemaDeserializer {
+    async fn deserialize(
+        &mut self,
+        message_bytes: &[u8],
+    ) -> Result<Value, MessageDeserializationError> {
+        let reader_result = match &self.schema {
+            None => apache_avro::Reader::new(Cursor::new(message_bytes)),
+            Some(schema) => apache_avro::Reader::with_schema(&schema, Cursor::new(message_bytes)),
+        };
+
+        match reader_result {
+            Ok(reader) => {
+                for r in reader {
+                    let v = match r {
+                        Err(_) => return Err(MessageDeserializationError::EmptyPayload),
+                        Ok(v) => Value::try_from(v),
+                    };
+
+                    return match v {
+                        Ok(value) => Ok(value),
+                        Err(e) => Err(MessageDeserializationError::AvroDeserialization {
+                            dead_letter: DeadLetter::from_failed_deserialization(
+                                message_bytes,
+                                e.to_string(),
+                            ),
+                        }),
+                    };
+                }
+                return Err(MessageDeserializationError::EmptyPayload);
+                // TODO: Code to return multiple values from avro message
+                /*let (values, errors): (Vec<_>, Vec<_>) =
+                    reader.into_iter().partition(Result::is_ok);
+                if errors.len() > 0 {
+                    let error_string = errors
+                        .iter()
+                        .map(|m| m.err().unwrap().to_string())
+                        .fold(String::new(), |current, next| current + "\n" + &next);
+                    return Err(MessageDeserializationError::AvroDeserialization {
+                        dead_letter: DeadLetter::from_failed_deserialization(
+                            message_bytes,
+                            error_string,
+                        ),
+                    });
+                }
+                let (transformed, t_errors): (Vec<_>, Vec<_>) = values
+                    .into_iter()
+                    .map(|v| v.unwrap())
+                    .map(Value::try_from)
+                    .partition(Result::is_ok);
+
+                if t_errors.len() > 0 {
+                    let error_string = t_errors
+                        .iter()
+                        .map(|m| m.err().unwrap().to_string())
+                        .fold(String::new(), |current, next| current + "\n" + &next);
+                    return Err(MessageDeserializationError::AvroDeserialization {
+                        dead_letter: DeadLetter::from_failed_deserialization(
+                            message_bytes,
+                            error_string,
+                        ),
+                    });
+                }
+
+                Ok(transformed.into_iter().map(|m| m.unwrap()).collect())*/
+            }
+            Err(e) => Err(MessageDeserializationError::AvroDeserialization {
+                dead_letter: DeadLetter::from_failed_deserialization(message_bytes, e.to_string()),
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl MessageDeserializer for JsonDeserializer {
+    async fn deserialize(
+        &mut self,
+        message_bytes: &[u8],
+    ) -> Result<Value, MessageDeserializationError> {
+        let decoder = self.decoder.borrow_mut();
+        match decoder.decode(Some(message_bytes)).await {
+            Ok(drs) => match drs {
+                Some(v) => match Value::try_from(v.value) {
+                    Ok(v) => Ok(v),
+                    Err(e) => Err(MessageDeserializationError::AvroDeserialization {
+                        dead_letter: DeadLetter::from_failed_deserialization(
+                            message_bytes,
+                            e.to_string(),
+                        ),
+                    }),
+                },
+                None => return Err(MessageDeserializationError::EmptyPayload),
+            },
+            Err(e) => {
+                return Err(MessageDeserializationError::AvroDeserialization {
+                    dead_letter: DeadLetter::from_failed_deserialization(
+                        message_bytes,
+                        e.to_string(),
+                    ),
+                });
+            }
+        }
+    }
+}
+impl JsonDeserializer {
+    pub(crate) fn from_schema_registry(sr_settings: SrSettings) -> Self {
+        return JsonDeserializer {
+            decoder: EasyJsonDecoder::new(sr_settings),
+        };
+    }
+}
+
+impl AvroSchemaDeserializer {
+    pub(crate) fn try_from_schema_file(file: &str) -> Result<Self, anyhow::Error> {
+        match std::fs::read_to_string(file) {
+            Ok(content) => match apache_avro::Schema::parse_str(&content) {
+                Ok(s) => Ok(AvroSchemaDeserializer { schema: Some(s) }),
+                Err(e) => Err(anyhow::format_err!("{}", e.to_string())),
+            },
+            Err(e) => Err(anyhow::format_err!("{}", e.to_string())),
+        }
+    }
+}
+
+impl Default for AvroSchemaDeserializer {
+    fn default() -> Self {
+        Self { schema: None }
+    }
+}
+
+impl AvroDeserializer {
+    pub(crate) fn from_schema_registry(sr_settings: SrSettings) -> Self {
+        return AvroDeserializer {
+            decoder: EasyAvroDecoder::new(sr_settings),
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/tests/data/default_schema.avro
+++ b/tests/data/default_schema.avro
@@ -1,0 +1,9 @@
+{
+    "type": "record",
+    "name": "test",
+    "fields": [
+        {"name": "id", "type": "long"},
+        {"name": "name", "type": "string"},
+        {"name": "date", "type": "string"}
+    ]
+}

--- a/tests/deserialization_tests.rs
+++ b/tests/deserialization_tests.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serial_test::serial;
 
-static DEFAULT_AVRO_SCHEMA: &'static str = r#"{
+const DEFAULT_AVRO_SCHEMA: &str = r#"{
     "type": "record",
     "name": "test",
     "fields": [
@@ -25,11 +25,11 @@ static DEFAULT_AVRO_SCHEMA: &'static str = r#"{
         {"name": "date", "type": "string"}
     ]
 }"#;
-static SCHEMA_PATH: &'static str = "tests/data/default_schema.avro";
-static DEFAULT_ID: i64 = 1;
-static DEFAULT_DATE: &'static str = "2023-06-30";
-static DEFAULT_NAME: &'static str = "test";
-static SCHEMA_REGISTRY_ADDRESS: &'static str = "http://localhost:8081";
+const SCHEMA_PATH: &str = "tests/data/default_schema.avro";
+const DEFAULT_ID: i64 = 1;
+const DEFAULT_DATE: &str = "2023-06-30";
+const DEFAULT_NAME: &str = "test";
+const SCHEMA_REGISTRY_ADDRESS: &str = "http://localhost:8081";
 
 #[tokio::test]
 #[serial]

--- a/tests/deserialization_tests.rs
+++ b/tests/deserialization_tests.rs
@@ -156,7 +156,7 @@ async fn test_json_with_registry() {
     rt.shutdown_background();
 }
 
-`#[tokio::test]
+#[tokio::test]
 #[serial]
 async fn test_avro_default() {
     let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(

--- a/tests/deserialization_tests.rs
+++ b/tests/deserialization_tests.rs
@@ -1,0 +1,348 @@
+#[allow(dead_code)]
+mod helpers;
+
+use kafka_delta_ingest::{IngestOptions, MessageFormat, SchemaSource};
+use log::info;
+use schema_registry_converter::{
+    async_impl::{
+        easy_avro::EasyAvroEncoder,
+        easy_json::EasyJsonEncoder,
+        schema_registry::{post_schema, SrSettings},
+    },
+    error::SRCError,
+    schema_registry_common::{RegisteredSchema, SchemaType, SubjectNameStrategy, SuppliedSchema},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serial_test::serial;
+
+static DEFAULT_AVRO_SCHEMA: &'static str = r#"{
+    "type": "record",
+    "name": "test",
+    "fields": [
+        {"name": "id", "type": "long"},
+        {"name": "name", "type": "string"},
+        {"name": "date", "type": "string"}
+    ]
+}"#;
+static SCHEMA_PATH: &'static str = "tests/data/default_schema.avro";
+static DEFAULT_ID: i64 = 1;
+static DEFAULT_DATE: &'static str = "2023-06-30";
+static DEFAULT_NAME: &'static str = "test";
+static SCHEMA_REGISTRY_ADDRESS: &'static str = "http://localhost:8081";
+
+#[tokio::test]
+#[serial]
+async fn test_json_default() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+        "test_json_default",
+        default_schema(),
+        vec!["date"],
+        1,
+        Some(IngestOptions {
+            app_id: "test_json_default".to_string(),
+            // buffer for 5 seconds before flush
+            allowed_latency: 5,
+            // large value - avoid flushing on num messages
+            max_messages_per_batch: 1,
+            // large value - avoid flushing on file size
+            min_bytes_per_file: 1000000,
+            ..Default::default()
+        }),
+    )
+    .await;
+
+    let data = json!({
+        "name": DEFAULT_NAME,
+        "id": DEFAULT_ID,
+        "date": DEFAULT_DATE,
+    });
+    info!("Writing test message");
+    helpers::send_json(&producer, &topic, &data).await;
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 1);
+
+    let v1_rows: Vec<TestMsg> = helpers::read_table_content_at_version_as(&table, 1).await;
+    assert_eq!(v1_rows.len(), 1);
+    assert_defaults(&v1_rows[0]);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_json_with_args() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+        "test_json_with_args",
+        default_schema(),
+        vec!["date"],
+        1,
+        Some(IngestOptions {
+            app_id: "test_json_with_args".to_string(),
+            // buffer for 5 seconds before flush
+            allowed_latency: 5,
+            // large value - avoid flushing on num messages
+            max_messages_per_batch: 1,
+            // large value - avoid flushing on file size
+            min_bytes_per_file: 1000000,
+            input_format: MessageFormat::Json(SchemaSource::None),
+            ..Default::default()
+        }),
+    )
+    .await;
+
+    let data = json!({
+        "name": DEFAULT_NAME,
+        "id": DEFAULT_ID,
+        "date": DEFAULT_DATE,
+    });
+    info!("Writing test message");
+    helpers::send_json(&producer, &topic, &data).await;
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 1);
+
+    let v1_rows: Vec<TestMsg> = helpers::read_table_content_at_version_as(&table, 1).await;
+    assert_eq!(v1_rows.len(), 1);
+    assert_defaults(&v1_rows[0]);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_json_with_registry() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+        "test_json_with_registry",
+        default_schema(),
+        vec!["date"],
+        1,
+        Some(IngestOptions {
+            app_id: "test_json_with_registry".to_string(),
+            // buffer for 5 seconds before flush
+            allowed_latency: 5,
+            // large value - avoid flushing on num messages
+            max_messages_per_batch: 1,
+            // large value - avoid flushing on file size
+            min_bytes_per_file: 1000000,
+            input_format: MessageFormat::Json(SchemaSource::SchemaRegistry(String::from(
+                SCHEMA_REGISTRY_ADDRESS,
+            ))),
+            ..Default::default()
+        }),
+    )
+    .await;
+
+    let data = json!({
+        "name": DEFAULT_NAME,
+        "id": DEFAULT_ID,
+        "date": DEFAULT_DATE,
+    });
+    info!("Writing test message");
+    prepare_json_schema(topic.clone()).await.unwrap();
+    let encoded = json_encode(&data, topic.clone()).await.unwrap();
+    helpers::send_encoded(&producer, &topic, encoded).await;
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 1);
+
+    let v1_rows: Vec<TestMsg> = helpers::read_table_content_at_version_as(&table, 1).await;
+    assert_eq!(v1_rows.len(), 1);
+    assert_defaults(&v1_rows[0]);
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_avro_default() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+        "test_avro_default",
+        default_schema(),
+        vec!["date"],
+        1,
+        Some(IngestOptions {
+            app_id: "test_avro_default".to_string(),
+            // buffer for 5 seconds before flush
+            allowed_latency: 5,
+            // large value - avoid flushing on num messages
+            max_messages_per_batch: 1,
+            // large value - avoid flushing on file size
+            min_bytes_per_file: 1000000,
+            input_format: MessageFormat::Avro(SchemaSource::None),
+            ..Default::default()
+        }),
+    )
+    .await;
+
+    let schema = apache_avro::Schema::parse_str(DEFAULT_AVRO_SCHEMA).unwrap();
+    let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+    let mut record = apache_avro::types::Record::new(writer.schema()).unwrap();
+    record.put("id", DEFAULT_ID);
+    record.put("name", DEFAULT_NAME);
+    record.put("date", DEFAULT_DATE);
+    writer.append(record).unwrap();
+    let encoded = writer.into_inner().unwrap();
+    helpers::send_encoded(&producer, &topic, encoded).await;
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 1);
+
+    let v1_rows: Vec<TestMsg> = helpers::read_table_content_at_version_as(&table, 1).await;
+    assert_eq!(v1_rows.len(), 1);
+    assert_defaults(&v1_rows[0]);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_avro_with_file() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+        "test_avro_with_file",
+        default_schema(),
+        vec!["date"],
+        1,
+        Some(IngestOptions {
+            app_id: "test_avro_with_file".to_string(),
+            // buffer for 5 seconds before flush
+            allowed_latency: 5,
+            // large value - avoid flushing on num messages
+            max_messages_per_batch: 1,
+            // large value - avoid flushing on file size
+            min_bytes_per_file: 1000000,
+            input_format: MessageFormat::Avro(SchemaSource::File(String::from(SCHEMA_PATH))),
+            ..Default::default()
+        }),
+    )
+    .await;
+
+    let schema = apache_avro::Schema::parse_str(DEFAULT_AVRO_SCHEMA).unwrap();
+    let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+    let mut record = apache_avro::types::Record::new(writer.schema()).unwrap();
+    record.put("id", DEFAULT_ID);
+    record.put("name", DEFAULT_NAME);
+    record.put("date", DEFAULT_DATE);
+    writer.append(record).unwrap();
+    let encoded = writer.into_inner().unwrap();
+    helpers::send_encoded(&producer, &topic, encoded).await;
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 1);
+
+    let v1_rows: Vec<TestMsg> = helpers::read_table_content_at_version_as(&table, 1).await;
+    assert_eq!(v1_rows.len(), 1);
+    assert_defaults(&v1_rows[0]);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_avro_with_registry() {
+    let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(
+        "test_avro_with_registry",
+        default_schema(),
+        vec!["date"],
+        1,
+        Some(IngestOptions {
+            app_id: "flush_when_latency_expires".to_string(),
+            // buffer for 5 seconds before flush
+            allowed_latency: 5,
+            // large value - avoid flushing on num messages
+            max_messages_per_batch: 1,
+            // large value - avoid flushing on file size
+            min_bytes_per_file: 1000000,
+            input_format: MessageFormat::Avro(SchemaSource::SchemaRegistry(String::from(
+                SCHEMA_REGISTRY_ADDRESS,
+            ))),
+            ..Default::default()
+        }),
+    )
+    .await;
+
+    let data = TestMsg {
+        id: DEFAULT_ID,
+        name: String::from(DEFAULT_NAME),
+        date: String::from(DEFAULT_DATE),
+    };
+    prepare_avro_schema(topic.clone()).await.unwrap();
+    let encoded = avro_encode(&data, topic.clone()).await.unwrap();
+    helpers::send_encoded(&producer, &topic, encoded).await;
+    // wait for latency flush
+    helpers::wait_until_version_created(&table, 1);
+
+    let v1_rows: Vec<TestMsg> = helpers::read_table_content_at_version_as(&table, 1).await;
+    assert_eq!(v1_rows.len(), 1);
+    assert_defaults(&v1_rows[0]);
+
+    token.cancel();
+    kdi.await.unwrap();
+    rt.shutdown_background();
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+struct TestMsg {
+    id: i64,
+    date: String,
+    name: String,
+}
+
+fn default_settings() -> SrSettings {
+    SrSettings::new(String::from(String::from(SCHEMA_REGISTRY_ADDRESS)))
+}
+
+async fn avro_encode(item: impl Serialize, topic: String) -> Result<Vec<u8>, SRCError> {
+    EasyAvroEncoder::new(default_settings())
+        .encode_struct(item, &SubjectNameStrategy::RecordNameStrategy(topic))
+        .await
+}
+
+async fn json_encode(value: &serde_json::Value, topic: String) -> Result<Vec<u8>, SRCError> {
+    EasyJsonEncoder::new(default_settings())
+        .encode(value, SubjectNameStrategy::RecordNameStrategy(topic))
+        .await
+}
+
+async fn prepare_json_schema(topic: String) -> Result<RegisteredSchema, SRCError> {
+    let settings = default_settings();
+    let schema = SuppliedSchema {
+        name: None,
+        schema_type: SchemaType::Json,
+        schema: String::from(
+            r#"{"schemaType": "JSON", "schema": "{\"type\": \"object\", \"properties\": {\"name\": {\"type\": \"string\"}, \"date\": {\"type\": \"string\"}, \"id\": {\"type\": \"number\"}}}"}"#,
+        ),
+        references: vec![],
+    };
+    post_schema(&settings, topic, schema).await
+}
+
+async fn prepare_avro_schema(topic: String) -> Result<RegisteredSchema, SRCError> {
+    let settings = default_settings();
+    let schema = SuppliedSchema {
+        name: None,
+        schema_type: SchemaType::Avro,
+        schema: String::from(DEFAULT_AVRO_SCHEMA),
+        references: vec![],
+    };
+    post_schema(&settings, topic, schema).await
+}
+
+fn assert_defaults(msg: &TestMsg) {
+    assert_eq!(msg.id, DEFAULT_ID);
+    assert_eq!(msg.name, DEFAULT_NAME);
+    assert_eq!(msg.date, DEFAULT_DATE);
+}
+
+fn default_schema() -> serde_json::Value {
+    json!({
+        "name": "string",
+        "id": "integer",
+        "date": "string",
+    })
+}

--- a/tests/deserialization_tests.rs
+++ b/tests/deserialization_tests.rs
@@ -156,7 +156,7 @@ async fn test_json_with_registry() {
     rt.shutdown_background();
 }
 
-#[tokio::test]
+`#[tokio::test]
 #[serial]
 async fn test_avro_default() {
     let (topic, table, producer, kdi, token, rt) = helpers::create_and_run_kdi(

--- a/tests/deserialization_tests.rs
+++ b/tests/deserialization_tests.rs
@@ -15,6 +15,9 @@ use schema_registry_converter::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serial_test::serial;
+use std::path::PathBuf;
+use std::str::FromStr;
+use url::Url;
 
 const DEFAULT_AVRO_SCHEMA: &str = r#"{
     "type": "record",
@@ -128,9 +131,9 @@ async fn test_json_with_registry() {
             max_messages_per_batch: 1,
             // large value - avoid flushing on file size
             min_bytes_per_file: 1000000,
-            input_format: MessageFormat::Json(SchemaSource::SchemaRegistry(String::from(
-                SCHEMA_REGISTRY_ADDRESS,
-            ))),
+            input_format: MessageFormat::Json(SchemaSource::SchemaRegistry(
+                Url::parse(SCHEMA_REGISTRY_ADDRESS).unwrap(),
+            )),
             ..Default::default()
         }),
     )
@@ -215,7 +218,9 @@ async fn test_avro_with_file() {
             max_messages_per_batch: 1,
             // large value - avoid flushing on file size
             min_bytes_per_file: 1000000,
-            input_format: MessageFormat::Avro(SchemaSource::File(String::from(SCHEMA_PATH))),
+            input_format: MessageFormat::Avro(SchemaSource::File(
+                PathBuf::from_str(SCHEMA_PATH).unwrap(),
+            )),
             ..Default::default()
         }),
     )
@@ -258,9 +263,9 @@ async fn test_avro_with_registry() {
             max_messages_per_batch: 1,
             // large value - avoid flushing on file size
             min_bytes_per_file: 1000000,
-            input_format: MessageFormat::Avro(SchemaSource::SchemaRegistry(String::from(
-                SCHEMA_REGISTRY_ADDRESS,
-            ))),
+            input_format: MessageFormat::Avro(SchemaSource::SchemaRegistry(
+                Url::parse(SCHEMA_REGISTRY_ADDRESS).unwrap(),
+            )),
             ..Default::default()
         }),
     )

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -70,6 +70,11 @@ pub async fn send_json(producer: &FutureProducer, topic: &str, json: &Value) -> 
     producer.send(record, Timeout::Never).await.unwrap()
 }
 
+pub async fn send_encoded(producer: &FutureProducer, topic: &str, content: Vec<u8>) -> (i32, i64) {
+    let record: FutureRecord<String, Vec<u8>> = FutureRecord::to(topic).payload(&content);
+    producer.send(record, Timeout::Never).await.unwrap()
+}
+
 pub async fn send_kv_json(
     producer: &FutureProducer,
     topic: &str,


### PR DESCRIPTION
This was prompted by a [slack thread](https://delta-users.slack.com/archives/C01Q2RXCVSQ/p1686672498735129). This adds support for avro with or without a schema. Additionally, it adds the ability to use the confluent schema registry for schemas.