### PR TITLE
Rebalance handling: reduce time holding write lock on signal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,18 +535,27 @@ async fn handle_rebalance(
     // if there is a revoke signal - we should skip the message, but not bother altering state yet.
     match rebalance_action {
         Some(RebalanceAction::ClearStateAndSkipMessage) => {
-            let mut rebalance_signal = rebalance_signal.write().await;
-            match rebalance_signal.as_mut() {
+            let rebalance_signal_val = rebalance_signal.write().await.take();
+            match rebalance_signal_val {
                 Some(RebalanceSignal::RebalanceAssign(partitions)) => {
                     info!(
                         "Handling rebalance assign. New assigned partitions are {:?}",
                         partitions
                     );
-                    processor.table.update().await?;
-                    partition_assignment.reset_with(partitions.as_slice());
-                    processor.reset_state(partition_assignment)?;
-                    *rebalance_signal = None;
-                    Err(IngestError::RebalanceInterrupt)
+                    if let Err(err) = processor.table.update().await {
+                        let mut rebalance_signal_val = rebalance_signal.write().await;
+                        // Set the signal back,
+                        // but only if it wasn't already replaced by a new one.
+                        if rebalance_signal_val.is_none() {
+                            *rebalance_signal_val =
+                                Some(RebalanceSignal::RebalanceAssign(partitions));
+                        }
+                        Err(err.into())
+                    } else {
+                        partition_assignment.reset_with(partitions.as_slice());
+                        processor.reset_state(partition_assignment)?;
+                        Err(IngestError::RebalanceInterrupt)
+                    }
                 }
                 _ => unreachable!(),
             }


### PR DESCRIPTION
This does not fix any open issue, it is rather something that was itching while reading the code. 

I'm wondering if you want to hold the write lock on the rebalance signal while handling the rebalance, so I've tried to minimize the time the lock is held. 

Current logic appears to be: 

- set the signal back to `None`, but only if there wasn't an error in `processor.table.update()`, so I've tried to keep that logic intact. 
- Also, since the lock is currently held while `processor.table.update()` is called, a new signal cannot replace it until the lock is dropped. Tried to keep that part too. 

With these changes, the base case--when there is no error handling the signal--will only see the write lock acquired once, and held for so long as it takes to call `take` on an `Option<_>`.