### PR TITLE
Add mode that terminates kdi when the end of a topic is reached

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ use crate::{
 use delta_helpers::*;
 use deltalake::checkpoints::CheckpointError;
 use std::ops::Add;
+use rdkafka::message::BorrowedMessage;
 
 /// Type alias for Kafka partition
 pub type DataTypePartition = i32;
@@ -158,7 +159,7 @@ pub enum IngestError {
     /// Error returned when a delta write fails.
     /// Ending Kafka offsets and counts for each partition are included to help identify the Kafka buffer that caused the write to fail.
     #[error(
-        "Delta write failed: ending_offsets: {ending_offsets}, partition_counts: {partition_counts}, source: {source}"
+    "Delta write failed: ending_offsets: {ending_offsets}, partition_counts: {partition_counts}, source: {source}"
     )]
     DeltaWriteFailed {
         /// Ending offsets for each partition that failed to be written to delta.
@@ -171,7 +172,7 @@ pub enum IngestError {
 
     /// Error returned when a message is received from Kafka that has already been processed.
     #[error(
-        "Partition offset has already been processed - partition: {partition}, offset: {offset}"
+    "Partition offset has already been processed - partition: {partition}, offset: {offset}"
     )]
     AlreadyProcessedPartitionOffset {
         /// The Kafka partition the message was received from
@@ -295,6 +296,8 @@ pub struct IngestOptions {
     pub statsd_endpoint: String,
     /// Input format
     pub input_format: MessageFormat,
+    /// Terminates when initial offsets are reached
+    pub end_at_last_offsets: bool,
 }
 
 impl Default for IngestOptions {
@@ -315,9 +318,11 @@ impl Default for IngestOptions {
             write_checkpoints: false,
             statsd_endpoint: "localhost:8125".to_string(),
             input_format: MessageFormat::DefaultJson,
+            end_at_last_offsets: false,
         }
     }
 }
+
 /// Executes a run loop to consume from a Kafka topic and write to a Delta table.
 pub async fn start_ingest(
     topic: String,
@@ -351,6 +356,12 @@ pub async fn start_ingest(
     let consumer = Arc::new(consumer);
     consumer.subscribe(&[topic.as_str()])?;
 
+    let _max_offsets = if opts.end_at_last_offsets {
+        Some(fetch_latest_offsets(&topic, &consumer)?)
+    } else {
+        None
+    };
+
     // Initialize metrics
     let ingest_metrics = IngestMetrics::new(opts.statsd_endpoint.as_str())?;
     // Initialize partition assignment tracking
@@ -362,8 +373,7 @@ pub async fn start_ingest(
         consumer.clone(),
         opts,
         ingest_metrics.clone(),
-    )
-    .await?;
+    ).await?;
 
     // Write seek_offsets if it's supplied and has not been written yet
     ingest_processor.write_offsets_to_delta_if_any().await?;
@@ -388,8 +398,8 @@ pub async fn start_ingest(
             rebalance_signal.clone(),
             &mut partition_assignment,
             &mut ingest_processor,
-        )
-        .await
+        ).await
+
         {
             match e {
                 IngestError::RebalanceInterrupt => continue,
@@ -417,8 +427,14 @@ pub async fn start_ingest(
                 // Increment the consumed message counter.
                 consumed += 1;
 
-                // Process the message if there wasn't a rebalance signal
                 let message = message?;
+
+                if let Some(offset_map) = &_max_offsets {
+                    if end_of_partition_reached(&message, offset_map) {
+                        unassign_partition(cancellation_token.clone(), consumer.clone(), &message)?;
+                    }
+                }
+                // Process the message if there wasn't a rebalance signal
                 if let Err(e) = ingest_processor.process_message(message).await {
                     match e {
                         IngestError::AlreadyProcessedPartitionOffset { partition, offset } => {
@@ -504,6 +520,58 @@ pub async fn start_ingest(
     }
 }
 
+fn end_of_partition_reached(message: &BorrowedMessage,
+                            offset_map: &HashMap<DataTypePartition, DataTypeOffset>) -> bool{
+    let partition = message.partition() as DataTypePartition;
+    let offset = &(message.offset() as DataTypeOffset);
+    let max_offset = offset_map.get(&partition).unwrap();
+    max_offset == offset
+}
+
+fn unassign_partition(cancellation_token: Arc<CancellationToken>, consumer: Arc<StreamConsumer<KafkaContext>>, message: &BorrowedMessage) -> Result<(), IngestError> {
+    let mut tpl = TopicPartitionList::new();
+    let partition = message.partition();
+    tpl.add_partition(message.topic(), partition);
+
+    // Remove the partition of this message from the assigned partitions
+    let assignment = consumer.assignment()?
+        .elements()
+        .iter()
+        .filter(|tp| {
+            tp.topic() != message.topic() || (tp.topic() == message.topic() && tp.partition() != message.partition())
+        })
+        .map(|tp| ((tp.topic().to_string(), tp.partition()), tp.offset()))
+        .collect::<HashMap<_, _>>();
+
+    let new_assignment = TopicPartitionList::from_topic_map(&assignment)?;
+    consumer.assign(&new_assignment)?;
+    log::info!("Reached the end of partition {}, removing assignment", partition);
+
+    if new_assignment.count() == 0 {
+        log::info!("Reached the end of partition {}, terminating", partition);
+        cancellation_token.cancel();
+    }
+
+    Ok(())
+}
+
+fn fetch_latest_offsets(topic: &String, consumer: &Arc<StreamConsumer<KafkaContext>>) -> Result<HashMap<DataTypePartition, DataTypeOffset>, IngestError> {
+    let metadata = &consumer
+        .fetch_metadata(Some(topic.as_ref()), Timeout::Never)?;
+
+    let partition_meta = metadata
+        .topics()
+        .iter()
+        .filter(|t| t.name() == topic)
+        .collect::<Vec<_>>()
+        .first()
+        .unwrap()
+        .partitions();
+    let partitions = partition_meta.iter().map(|p| p.id() as DataTypePartition).collect::<Vec<_>>();
+    let result = get_high_watermark_map(topic.as_str(), consumer.clone(), partitions.into_iter())?;
+    Ok(result)
+}
+
 /// Handles a [`RebalanceSignal`] if one exists.
 /// The [`RebalanceSignal`] is wrapped in a tokio [`RwLock`] so that it can be written to from the thread that receives rebalance events from [`rdkafka`].
 /// Writing a new rebalance signal is implemented in [`KafkaContext`].
@@ -564,10 +632,10 @@ fn should_record_buffer_lag(last_buffer_lag_report: &Option<Instant>) -> bool {
     match last_buffer_lag_report {
         None => true,
         Some(last_buffer_lag_report)
-            if last_buffer_lag_report.elapsed().as_secs() >= BUFFER_LAG_REPORT_SECONDS =>
-        {
-            true
-        }
+        if last_buffer_lag_report.elapsed().as_secs() >= BUFFER_LAG_REPORT_SECONDS =>
+            {
+                true
+            }
         _ => false,
     }
 }
@@ -709,8 +777,8 @@ impl IngestProcessor {
     /// Processes a single message received from Kafka.
     /// This method deserializes, transforms and writes the message to buffers.
     async fn process_message<M>(&mut self, message: M) -> Result<(), IngestError>
-    where
-        M: Message + Send + Sync,
+        where
+            M: Message + Send + Sync,
     {
         let partition = message.partition();
         let offset = message.offset();
@@ -773,8 +841,8 @@ impl IngestProcessor {
         &mut self,
         msg: &M,
     ) -> Result<Value, MessageDeserializationError>
-    where
-        M: Message + Send + Sync,
+        where
+            M: Message + Send + Sync,
     {
         let message_bytes = match msg.payload() {
             Some(b) => b,
@@ -896,8 +964,8 @@ impl IngestProcessor {
                 },
                 &self.table.state,
                 None,
-            )
-            .await
+            ).await
+
             {
                 Ok(v) => {
                     /*if v != version {
@@ -1021,7 +1089,7 @@ impl IngestProcessor {
 
         let should = self.value_buffers.len() > 0
             && (self.value_buffers.len() == self.opts.max_messages_per_batch
-                || elapsed_millis >= (self.opts.allowed_latency * 1000) as u128);
+            || elapsed_millis >= (self.opts.allowed_latency * 1000) as u128);
 
         debug!(
             "Should complete record batch - latency test: {} >= {}",
@@ -1043,7 +1111,7 @@ impl IngestProcessor {
 
         let should = self.delta_writer.buffer_len() > 0
             && (self.delta_writer.buffer_len() >= self.opts.min_bytes_per_file
-                || elapsed_secs >= self.opts.allowed_latency);
+            || elapsed_secs >= self.opts.allowed_latency);
 
         debug!(
             "Should complete file - latency test: {} >= {}",
@@ -1243,8 +1311,7 @@ async fn dead_letter_queue_from_options(
         delta_table_uri: opts.dlq_table_uri.clone(),
         dead_letter_transforms: opts.dlq_transforms.clone(),
         write_checkpoints: opts.write_checkpoints,
-    })
-    .await
+    }).await
 }
 
 /// Creates a vec of partition numbers from a topic partition list.
@@ -1263,15 +1330,28 @@ fn get_high_watermarks<I>(
     topic: &str,
     consumer: Arc<StreamConsumer<KafkaContext>>,
     partitions: I,
-) -> Result<Vec<i64>, KafkaError>
-where
-    I: Iterator<Item = DataTypePartition>,
+) -> Result<Vec<DataTypeOffset>, KafkaError>
+    where
+        I: Iterator<Item=DataTypePartition>
+{
+    get_high_watermark_map(topic, consumer, partitions)
+        .map(|hashmap| hashmap.into_values().collect::<Vec<_>>())
+}
+
+/// Fetches high watermarks (latest offsets) with partitions from Kafka from the iterator of partitions.
+fn get_high_watermark_map<I>(
+    topic: &str,
+    consumer: Arc<StreamConsumer<KafkaContext>>,
+    partitions: I,
+) -> Result<HashMap<DataTypePartition, DataTypeOffset>, KafkaError>
+    where
+        I: Iterator<Item=DataTypePartition>
 {
     partitions
         .map(|partition| {
             consumer
                 .fetch_watermarks(topic, partition, Timeout::Never)
-                .map(|(_, latest_offset)| latest_offset)
+                .map(|(_, latest_offset)| (partition, latest_offset as DataTypeOffset))
         })
         .collect()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,8 @@ use crate::{
 };
 use delta_helpers::*;
 use deltalake::checkpoints::CheckpointError;
-use std::ops::Add;
 use rdkafka::message::BorrowedMessage;
+use std::ops::Add;
 
 /// Type alias for Kafka partition
 pub type DataTypePartition = i32;
@@ -172,7 +172,7 @@ pub enum IngestError {
 
     /// Error returned when a message is received from Kafka that has already been processed.
     #[error(
-    "Partition offset has already been processed - partition: {partition}, offset: {offset}"
+        "Partition offset has already been processed - partition: {partition}, offset: {offset}"
     )]
     AlreadyProcessedPartitionOffset {
         /// The Kafka partition the message was received from
@@ -373,7 +373,8 @@ pub async fn start_ingest(
         consumer.clone(),
         opts,
         ingest_metrics.clone(),
-    ).await?;
+    )
+    .await?;
 
     // Write seek_offsets if it's supplied and has not been written yet
     ingest_processor.write_offsets_to_delta_if_any().await?;
@@ -398,8 +399,8 @@ pub async fn start_ingest(
             rebalance_signal.clone(),
             &mut partition_assignment,
             &mut ingest_processor,
-        ).await
-
+        )
+        .await
         {
             match e {
                 IngestError::RebalanceInterrupt => continue,
@@ -520,32 +521,43 @@ pub async fn start_ingest(
     }
 }
 
-fn end_of_partition_reached(message: &BorrowedMessage,
-                            offset_map: &HashMap<DataTypePartition, DataTypeOffset>) -> bool{
+fn end_of_partition_reached(
+    message: &BorrowedMessage,
+    offset_map: &HashMap<DataTypePartition, DataTypeOffset>,
+) -> bool {
     let partition = message.partition() as DataTypePartition;
     let offset = &(message.offset() as DataTypeOffset);
     let max_offset = offset_map.get(&partition).unwrap();
     max_offset == offset
 }
 
-fn unassign_partition(cancellation_token: Arc<CancellationToken>, consumer: Arc<StreamConsumer<KafkaContext>>, message: &BorrowedMessage) -> Result<(), IngestError> {
+fn unassign_partition(
+    cancellation_token: Arc<CancellationToken>,
+    consumer: Arc<StreamConsumer<KafkaContext>>,
+    message: &BorrowedMessage,
+) -> Result<(), IngestError> {
     let mut tpl = TopicPartitionList::new();
     let partition = message.partition();
     tpl.add_partition(message.topic(), partition);
 
     // Remove the partition of this message from the assigned partitions
-    let assignment = consumer.assignment()?
+    let assignment = consumer
+        .assignment()?
         .elements()
         .iter()
         .filter(|tp| {
-            tp.topic() != message.topic() || (tp.topic() == message.topic() && tp.partition() != message.partition())
+            tp.topic() != message.topic()
+                || (tp.topic() == message.topic() && tp.partition() != message.partition())
         })
         .map(|tp| ((tp.topic().to_string(), tp.partition()), tp.offset()))
         .collect::<HashMap<_, _>>();
 
     let new_assignment = TopicPartitionList::from_topic_map(&assignment)?;
     consumer.assign(&new_assignment)?;
-    log::info!("Reached the end of partition {}, removing assignment", partition);
+    log::info!(
+        "Reached the end of partition {}, removing assignment",
+        partition
+    );
 
     if new_assignment.count() == 0 {
         log::info!("Reached the end of partition {}, terminating", partition);
@@ -555,9 +567,11 @@ fn unassign_partition(cancellation_token: Arc<CancellationToken>, consumer: Arc<
     Ok(())
 }
 
-fn fetch_latest_offsets(topic: &String, consumer: &Arc<StreamConsumer<KafkaContext>>) -> Result<HashMap<DataTypePartition, DataTypeOffset>, IngestError> {
-    let metadata = &consumer
-        .fetch_metadata(Some(topic.as_ref()), Timeout::Never)?;
+fn fetch_latest_offsets(
+    topic: &String,
+    consumer: &Arc<StreamConsumer<KafkaContext>>,
+) -> Result<HashMap<DataTypePartition, DataTypeOffset>, IngestError> {
+    let metadata = &consumer.fetch_metadata(Some(topic.as_ref()), Timeout::Never)?;
 
     let partition_meta = metadata
         .topics()
@@ -567,7 +581,10 @@ fn fetch_latest_offsets(topic: &String, consumer: &Arc<StreamConsumer<KafkaConte
         .first()
         .unwrap()
         .partitions();
-    let partitions = partition_meta.iter().map(|p| p.id() as DataTypePartition).collect::<Vec<_>>();
+    let partitions = partition_meta
+        .iter()
+        .map(|p| p.id() as DataTypePartition)
+        .collect::<Vec<_>>();
     let result = get_high_watermark_map(topic.as_str(), consumer.clone(), partitions.into_iter())?;
     Ok(result)
 }
@@ -632,10 +649,10 @@ fn should_record_buffer_lag(last_buffer_lag_report: &Option<Instant>) -> bool {
     match last_buffer_lag_report {
         None => true,
         Some(last_buffer_lag_report)
-        if last_buffer_lag_report.elapsed().as_secs() >= BUFFER_LAG_REPORT_SECONDS =>
-            {
-                true
-            }
+            if last_buffer_lag_report.elapsed().as_secs() >= BUFFER_LAG_REPORT_SECONDS =>
+        {
+            true
+        }
         _ => false,
     }
 }
@@ -777,8 +794,8 @@ impl IngestProcessor {
     /// Processes a single message received from Kafka.
     /// This method deserializes, transforms and writes the message to buffers.
     async fn process_message<M>(&mut self, message: M) -> Result<(), IngestError>
-        where
-            M: Message + Send + Sync,
+    where
+        M: Message + Send + Sync,
     {
         let partition = message.partition();
         let offset = message.offset();
@@ -841,8 +858,8 @@ impl IngestProcessor {
         &mut self,
         msg: &M,
     ) -> Result<Value, MessageDeserializationError>
-        where
-            M: Message + Send + Sync,
+    where
+        M: Message + Send + Sync,
     {
         let message_bytes = match msg.payload() {
             Some(b) => b,
@@ -964,8 +981,8 @@ impl IngestProcessor {
                 },
                 &self.table.state,
                 None,
-            ).await
-
+            )
+            .await
             {
                 Ok(v) => {
                     /*if v != version {
@@ -1089,7 +1106,7 @@ impl IngestProcessor {
 
         let should = self.value_buffers.len() > 0
             && (self.value_buffers.len() == self.opts.max_messages_per_batch
-            || elapsed_millis >= (self.opts.allowed_latency * 1000) as u128);
+                || elapsed_millis >= (self.opts.allowed_latency * 1000) as u128);
 
         debug!(
             "Should complete record batch - latency test: {} >= {}",
@@ -1111,7 +1128,7 @@ impl IngestProcessor {
 
         let should = self.delta_writer.buffer_len() > 0
             && (self.delta_writer.buffer_len() >= self.opts.min_bytes_per_file
-            || elapsed_secs >= self.opts.allowed_latency);
+                || elapsed_secs >= self.opts.allowed_latency);
 
         debug!(
             "Should complete file - latency test: {} >= {}",
@@ -1311,7 +1328,8 @@ async fn dead_letter_queue_from_options(
         delta_table_uri: opts.dlq_table_uri.clone(),
         dead_letter_transforms: opts.dlq_transforms.clone(),
         write_checkpoints: opts.write_checkpoints,
-    }).await
+    })
+    .await
 }
 
 /// Creates a vec of partition numbers from a topic partition list.
@@ -1331,8 +1349,8 @@ fn get_high_watermarks<I>(
     consumer: Arc<StreamConsumer<KafkaContext>>,
     partitions: I,
 ) -> Result<Vec<DataTypeOffset>, KafkaError>
-    where
-        I: Iterator<Item=DataTypePartition>
+where
+    I: Iterator<Item = DataTypePartition>,
 {
     get_high_watermark_map(topic, consumer, partitions)
         .map(|hashmap| hashmap.into_values().collect::<Vec<_>>())
@@ -1344,8 +1362,8 @@ fn get_high_watermark_map<I>(
     consumer: Arc<StreamConsumer<KafkaContext>>,
     partitions: I,
 ) -> Result<HashMap<DataTypePartition, DataTypeOffset>, KafkaError>
-    where
-        I: Iterator<Item=DataTypePartition>
+where
+    I: Iterator<Item = DataTypePartition>,
 {
     partitions
         .map(|partition| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,9 @@ async fn main() -> anyhow::Result<()> {
                 .unwrap()
                 .to_string();
 
+            let end_at_last_offsets = ingest_matches
+                .contains_id("end");
+
             let format = convert_matches_to_message_format(ingest_matches).unwrap();
 
             let options = IngestOptions {
@@ -153,6 +156,7 @@ async fn main() -> anyhow::Result<()> {
                 additional_kafka_settings,
                 statsd_endpoint,
                 input_format: format,
+                end_at_last_offsets,
             };
 
             tokio::spawn(async move {
@@ -419,6 +423,11 @@ This can be used to provide TLS configuration as in:
                             .group(ArgGroup::new("format")
                                     .args(["json", "avro"])
                                     .required(false))
+                            .arg(Arg::new("end")
+                                .long("ends_at_initial_offsets")
+                                .required(false)
+                                .num_args(0)
+                                .help(""))
                         )
                 .arg_required_else_help(true)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,7 +424,7 @@ This can be used to provide TLS configuration as in:
                                     .args(["json", "avro"])
                                     .required(false))
                             .arg(Arg::new("end")
-                                .long("ends_at_initial_offsets")
+                                .long("ends_at_latest_offsets")
                                 .required(false)
                                 .num_args(0)
                                 .help(""))

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,8 +135,7 @@ async fn main() -> anyhow::Result<()> {
                 .unwrap()
                 .to_string();
 
-            let end_at_last_offsets = ingest_matches
-                .contains_id("end");
+            let end_at_last_offsets = ingest_matches.contains_id("end");
 
             let format = convert_matches_to_message_format(ingest_matches).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,6 +424,7 @@ This can be used to provide TLS configuration as in:
                                     .args(["json", "avro"])
                                     .required(false))
                             .arg(Arg::new("end")
+                                .short('e')
                                 .long("ends_at_latest_offsets")
                                 .required(false)
                                 .num_args(0)

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -609,7 +609,7 @@ pub fn load_object_store_from_uri(
     options: Option<HashMap<String, String>>,
 ) -> DeltaResult<DeltaObjectStore> {
     match Url::parse(path) {
-        Ok(table_uri) => DeltaObjectStore::try_new(table_uri, options.unwrap_or(HashMap::new())),
+        Ok(table_uri) => DeltaObjectStore::try_new(table_uri, options.unwrap_or_default()),
         Err(url::ParseError::RelativeUrlWithoutBase) => {
             match std::path::Path::new(path).is_absolute() {
                 true => load_table_from_file_uri(path, options),
@@ -635,7 +635,7 @@ fn load_table_from_file_uri(
     options: Option<HashMap<String, String>>,
 ) -> DeltaResult<DeltaObjectStore> {
     let url = Url::from_file_path(absolute_path).unwrap();
-    DeltaObjectStore::try_new(url, options.unwrap_or(HashMap::new()))
+    DeltaObjectStore::try_new(url, options.unwrap_or_default())
 }
 
 type BadValue = (Value, ParquetError);

--- a/tests/end_at_last_offsets_test.rs
+++ b/tests/end_at_last_offsets_test.rs
@@ -1,0 +1,100 @@
+use deltalake::DeltaTable;
+use kafka_delta_ingest::IngestOptions;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use uuid::Uuid;
+
+#[allow(dead_code)]
+mod helpers;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Msg {
+    id: u32,
+    city: String,
+}
+
+impl Msg {
+    fn new(id: u32) -> Self {
+        Self {
+            id,
+            city: "default".to_string(),
+        }
+    }
+}
+
+#[tokio::test]
+async fn end_at_initial_offsets() {
+    helpers::init_logger();
+    let topic = format!("end_at_offset_{}", Uuid::new_v4());
+
+    let table = helpers::create_local_table(
+        json!({
+            "id": "integer",
+            "city": "string",
+        }),
+        vec!["city"],
+        &topic,
+    );
+    let table = table.as_str();
+
+    helpers::create_topic(&topic, 3).await;
+
+    let producer = helpers::create_producer();
+    // submit 15 messages in kafka
+    for i in 0..15 {
+        helpers::send_json(
+            &producer,
+            &topic,
+            &serde_json::to_value(Msg::new(i)).unwrap(),
+        )
+            .await;
+    }
+
+    let (kdi, _token, rt) = helpers::create_kdi(
+        &topic,
+        table,
+        IngestOptions {
+            app_id: topic.clone(),
+            allowed_latency: 5,
+            max_messages_per_batch: 20,
+            min_bytes_per_file: 20,
+            end_at_last_offsets: true,
+            ..Default::default()
+        },
+    );
+
+    helpers::wait_until_version_created(&table, 1);
+
+    {
+        // check that there's 3 records in table
+        let table = deltalake::open_table(table).await.unwrap();
+        assert_eq!(table.version(), 1);
+        assert_eq!(count_records(table), 15);
+    }
+
+    // messages in kafka
+    for i in 16..31 {
+        helpers::send_json(
+            &producer,
+            &topic,
+            &serde_json::to_value(Msg::new(i)).unwrap(),
+        )
+            .await;
+    }
+
+    helpers::expect_termination_within(kdi, 10).await;
+    rt.shutdown_background();
+
+    // check that there's only 3 records
+    let table = deltalake::open_table(table).await.unwrap();
+    assert_eq!(table.version(), 1);
+    assert_eq!(count_records(table), 15);
+}
+
+fn count_records(table: DeltaTable) -> i64 {
+    let mut count = 0;
+    for x in table.get_stats() {
+        count += x.as_ref().unwrap().as_ref().unwrap().num_records;
+    }
+    count
+}

--- a/tests/end_at_last_offsets_test.rs
+++ b/tests/end_at_last_offsets_test.rs
@@ -47,7 +47,7 @@ async fn end_at_initial_offsets() {
             &topic,
             &serde_json::to_value(Msg::new(i)).unwrap(),
         )
-            .await;
+        .await;
     }
 
     let (kdi, _token, rt) = helpers::create_kdi(
@@ -79,7 +79,7 @@ async fn end_at_initial_offsets() {
             &topic,
             &serde_json::to_value(Msg::new(i)).unwrap(),
         )
-            .await;
+        .await;
     }
 
     helpers::expect_termination_within(kdi, 10).await;

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -340,6 +340,24 @@ pub fn wait_until_version_created(table: &str, version: i64) {
     wait_until_file_created(FilePath::new(&path));
 }
 
+pub async fn expect_termination_within(kdi: JoinHandle<()>, seconds: i64){
+    let start_time = Local::now();
+    let timelimit = chrono::Duration::seconds(seconds);
+
+    loop {
+        if kdi.is_finished(){
+            kdi.await.unwrap();
+            return;
+        }
+        let now = Local::now();
+        let poll_time = now - start_time;
+
+        if poll_time > timelimit{
+            panic!("KDI did not terminate within timeout",);
+        }
+    }
+}
+
 pub async fn read_table_content_as<T: DeserializeOwned>(table_uri: &str) -> Vec<T> {
     read_table_content_as_jsons(table_uri)
         .await

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -340,19 +340,19 @@ pub fn wait_until_version_created(table: &str, version: i64) {
     wait_until_file_created(FilePath::new(&path));
 }
 
-pub async fn expect_termination_within(kdi: JoinHandle<()>, seconds: i64){
+pub async fn expect_termination_within(kdi: JoinHandle<()>, seconds: i64) {
     let start_time = Local::now();
     let timelimit = chrono::Duration::seconds(seconds);
 
     loop {
-        if kdi.is_finished(){
+        if kdi.is_finished() {
             kdi.await.unwrap();
             return;
         }
         let now = Local::now();
         let poll_time = now - start_time;
 
-        if poll_time > timelimit{
+        if poll_time > timelimit {
             panic!("KDI did not terminate within timeout",);
         }
     }


### PR DESCRIPTION
When the "-e" or "--ends_at_latest_offsets" is added as an argument the application terminates when the end of the topic is reached.
The end of the topic is determined by storing the highest offsets known on startup. When a partitions reaches this offset, the partition is unassigned from the consumer.

Fixes #75 

Curious to hear any feedback!