### PR TITLE
allow empty transform set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,14 +114,10 @@ async fn main() -> anyhow::Result<()> {
                 .get_one::<usize>("min_bytes_per_file")
                 .unwrap();
 
-            let transforms: HashMap<String, String> =
-            ingest_matches
+            let transforms: HashMap<String, String> = ingest_matches
                 .get_many::<String>("transform")
-                .map(|list| {
-                    list.map(|t| parse_transform(t).unwrap())
-                    .collect()
-
-                }).unwrap_or_else(|| HashMap::new());
+                .map(|list| list.map(|t| parse_transform(t).unwrap()).collect())
+                .unwrap_or_else(|| HashMap::new());
 
             let dlq_table_location = ingest_matches
                 .get_one::<String>("dlq_table_location")

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ async fn main() -> anyhow::Result<()> {
             let transforms: HashMap<String, String> = ingest_matches
                 .get_many::<String>("transform")
                 .map(|list| list.map(|t| parse_transform(t).unwrap()).collect())
-                .unwrap_or_else(|| HashMap::new());
+                .unwrap_or_else(HashMap::new);
 
             let dlq_table_location = ingest_matches
                 .get_one::<String>("dlq_table_location")

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,11 +114,14 @@ async fn main() -> anyhow::Result<()> {
                 .get_one::<usize>("min_bytes_per_file")
                 .unwrap();
 
-            let transforms: HashMap<String, String> = ingest_matches
+            let transforms: HashMap<String, String> =
+            ingest_matches
                 .get_many::<String>("transform")
-                .expect("Failed to parse transforms")
-                .map(|t| parse_transform(t).unwrap())
-                .collect();
+                .map(|list| {
+                    list.map(|t| parse_transform(t).unwrap())
+                    .collect()
+
+                }).unwrap_or_else(|| HashMap::new());
 
             let dlq_table_location = ingest_matches
                 .get_one::<String>("dlq_table_location")


### PR DESCRIPTION
sometimes the kafka message definition matches the table definition and I end up writing `--transform 'identity: identity'`