### PR TITLE
Add flag to support gzip compressed messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,6 +2768,7 @@ dependencies = [
  "dipstick",
  "dynamodb_lock",
  "env_logger",
+ "flate2",
  "futures",
  "jmespatch",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["R. Tyler Croy <rtyler@brokenco.de>", "Christian Williams <christianw
 edition = "2018"
 
 [dependencies]
+flate2 = "1.0"
 anyhow = "1"
 async-trait = "0.1"
 apache-avro = "^0.14"

--- a/README.adoc
+++ b/README.adoc
@@ -216,22 +216,6 @@ kafka-delta-ingest now supports ingestion of gzip-compressed messages. This can 
 
 To enable gzip decompression, use the `--decompress_gzip` flag when starting the ingestion process.
 
-Example usage:
-
-```bash
-RUST_LOG=debug cargo run ingest web_requests ./tests/data/web_requests \
-  --allowed_latency 60 \
-  --app_id web_requests \
-  --decompress_gzip \
-  --transform 'date: substr(meta.producer.timestamp, `0`, `10`)' \
-  --transform 'meta.kafka.offset: kafka.offset' \
-  --transform 'meta.kafka.partition: kafka.partition' \
-  --transform 'meta.kafka.topic: kafka.topic' \
-  --auto_offset_reset earliest
-```
-
-The --decompress_gzip flag tells kafka-delta-ingest to decompress gzip-compressed Kafka messages before processing them.
-
 == Writing to S3
 
 When writing to S3, you may experience an error like `source: StorageError { source: S3Generic("dynamodb locking is not enabled") }`.

--- a/README.adoc
+++ b/README.adoc
@@ -210,6 +210,28 @@ Make sure to provide the additional option:
 
 when invoking the cli command as well.
 
+== Gzip Compressed Messages
+
+kafka-delta-ingest now supports ingestion of gzip-compressed messages. This can be particularly useful when dealing with large volumes of data that benefit from compression.
+
+To enable gzip decompression, use the `--decompress_gzip` flag when starting the ingestion process.
+
+Example usage:
+
+```bash
+RUST_LOG=debug cargo run ingest web_requests ./tests/data/web_requests \
+  --allowed_latency 60 \
+  --app_id web_requests \
+  --decompress_gzip \
+  --transform 'date: substr(meta.producer.timestamp, `0`, `10`)' \
+  --transform 'meta.kafka.offset: kafka.offset' \
+  --transform 'meta.kafka.partition: kafka.partition' \
+  --transform 'meta.kafka.topic: kafka.topic' \
+  --auto_offset_reset earliest
+```
+
+The --decompress_gzip flag tells kafka-delta-ingest to decompress gzip-compressed Kafka messages before processing them.
+
 == Writing to S3
 
 When writing to S3, you may experience an error like `source: StorageError { source: S3Generic("dynamodb locking is not enabled") }`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,8 @@ async fn main() -> anyhow::Result<()> {
 
             let end_at_last_offsets = ingest_matches.get_flag("end");
 
+            let decompress_gzip = ingest_matches.get_flag("decompress_gzip");
+
             // ingest_matches.get_flag("end")
             let format = convert_matches_to_message_format(ingest_matches).unwrap();
 
@@ -161,6 +163,7 @@ async fn main() -> anyhow::Result<()> {
                 statsd_endpoint,
                 input_format: format,
                 end_at_last_offsets,
+                decompress_gzip,
             };
 
             tokio::spawn(async move {
@@ -452,6 +455,11 @@ This can be used to provide TLS configuration as in:
                     .num_args(0)
                     .action(ArgAction::SetTrue)
                     .help(""))
+                .arg(Arg::new("decompress_gzip")
+                    .long("decompress_gzip")
+                    .env("DECOMPRESS_GZIP")
+                    .help("Enable gzip decompression for incoming messages")
+                    .action(ArgAction::SetTrue))
         )
         .arg_required_else_help(true)
 }


### PR DESCRIPTION
# Gzip decompression flag

## Summary

This pull request introduces support for ingesting gzip-compressed messages in the `kafka-delta-ingest` project. This new functionality allows users to handle gzip-compressed Kafka messages, decompressing them before further processing and ingestion into Delta Lake.

## Changes

1. **New Feature: Gzip Decompression**
   - Added the `--decompress_gzip` flag to the command-line options.
   - Modified the `MessageDeserializerFactory` and related deserialization logic to support gzip decompression.
   - Updated `main.rs` to handle the new command-line argument and pass it to the deserialization process.
   - Updated `lib.rs` to integrate the new gzip decompression functionality.

## Notes

- I tested the new functionality with both gzip-compressed and uncompressed messages to ensure compatibility and correct behavior in both scenarios.
- While I have tested the feature manually, I did not write automated tests for this new functionality. If this change is accepted and additional tests are required, I would be happy to help implement them with some guidance on the specific test cases and scenarios that need to be covered.
- I noticed that sometimes the github action tests fail (in older commits as well) with the following error:

```
---- test_start_from_latest stdout ----
thread 'test_start_from_latest' panicked at tests/helpers/mod.rs:361:13:
File was not created before timeout
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_start_from_latest

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 203.42s
```

However since this happens to older commits, it seems to not be caused by this new functionality. 

## Usage

Use the `--decompress_gzip` flag to enable gzip decompression. Ensure that the Kafka producer is configured to produce gzip-compressed messages.

```bash
RUST_LOG=debug cargo run ingest <kafka_topic> <delta_table_path> \
  --allowed_latency 60 \
  --app_id <app_id> \
  --decompress_gzip \
  --auto_offset_reset earliest
```

This command enables gzip decompression for Kafka messages ingested into the Delta Lake table.

## Conclusion

This enhancement allows for more flexible and efficient processing of Kafka messages, particularly in environments where data compression is essential. Please review the changes and let me know if any adjustments or additional tests are required. Thank you for considering this contribution.
