### PR TITLE
chore: upgrade to the latest deltalake release(s)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-delta-ingest"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["R. Tyler Croy <rtyler@brokenco.de>", "Christian Williams <christianw@scribd.com>"]
 edition = "2018"
 
@@ -34,9 +34,9 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 url = "2.3"
 
 # datafusion feature is required for writer version 2
-deltalake-core = { version = "0.20.0", features = ["json", "datafusion"]}
-deltalake-aws = { version = "0.3.0", optional = true }
-deltalake-azure = { version = "0.3.0", optional = true }
+deltalake-core = { version = "0.21.0", features = ["json", "datafusion"]}
+deltalake-aws = { version = "0.4.0", optional = true }
+deltalake-azure = { version = "0.4.0", optional = true }
 
 # s3 feature enabled, helps for locking interactions with DLQ
 dynamodb_lock = { version = "0.6.0", optional = true }


### PR DESCRIPTION
The most recent release has a pretty substantial memory improvement for checkpoint creationg will is relevant here