### PR TITLE
Prevent the potential for a panic in the string_to_timestamp coercions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -476,8 +476,7 @@ fn convert_matches_to_message_format(
             .map(MessageFormat::Avro);
     }
 
-    return to_schema_source(ingest_matches.get_one::<String>("json"), true)
-        .map(MessageFormat::Json);
+    to_schema_source(ingest_matches.get_one::<String>("json"), true).map(MessageFormat::Json)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The original code was turning nanos into micros anyways, so we can use the more safe timestamp_micros() code.

For timestamp_nanos_opt() it can return None if the dates that cannot be represented as nanoseconds between 1677-09-21T00:12:43.145224192 and 2262-04-11T23:47:16.854775807.