### PR TITLE
chore: bump to default-engine-rustls fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,12 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 url = "2.3"
 
 # datafusion feature is required for writer version 2
-deltalake-core = { version = "0.23.0", features = ["json", "datafusion"]}
-deltalake-aws = { version = "0.6.0", optional = true }
-deltalake-azure = { version = "0.6.0", optional = true }
+#deltalake-core = { version = "0.23.0", features = ["json", "datafusion"]}
+#deltalake-aws = { version = "0.6.0", optional = true }
+#deltalake-azure = { version = "0.6.0", optional = true }
+deltalake-core = { git = "https://github.com/buoyant-data/delta-rs", branch = "default-engine-rustls", features = ["json", "datafusion"] }
+deltalake-aws = { git = "https://github.com/buoyant-data/delta-rs", branch = "default-engine-rustls", optional = true }
+deltalake-azure= { git = "https://github.com/buoyant-data/delta-rs", branch = "default-engine-rustls", optional = true }
 
 # s3 feature enabled, helps for locking interactions with DLQ
 dynamodb_lock = { version = "0.6.0", optional = true }

--- a/src/delta_helpers.rs
+++ b/src/delta_helpers.rs
@@ -52,10 +52,10 @@ pub(crate) async fn try_create_checkpoint(
             table.load_version(version).await?;
         }
 
-        deltalake_core::checkpoints::create_checkpoint(table).await?;
+        deltalake_core::checkpoints::create_checkpoint(table, None).await?;
         log::info!("Created checkpoint version {}.", version);
 
-        let removed = deltalake_core::checkpoints::cleanup_metadata(table).await?;
+        let removed = deltalake_core::checkpoints::cleanup_metadata(table, None).await?;
         if removed > 0 {
             log::info!("Metadata cleanup, removed {} obsolete logs.", removed);
         }

--- a/tests/delta_partitions_tests.rs
+++ b/tests/delta_partitions_tests.rs
@@ -116,7 +116,7 @@ async fn test_delta_partitions() {
         .expect("Failed to create transaction")
         .version;
 
-    deltalake_core::checkpoints::create_checkpoint(&table)
+    deltalake_core::checkpoints::create_checkpoint(&table, None)
         .await
         .unwrap();
 


### PR DESCRIPTION
This allows avoiding openssl without needing to juggle the newest released version of kernel (0.6.1) and delta-rs/datafusion/arrow versions