### PR TITLE
docker: cache volumes in build & debian for runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ contrib/
 target/
 venv/
 .github/
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,24 @@ FROM rust:1.81 AS builder
 
 RUN mkdir /build
 WORKDIR /build
-COPY ./ .
 
-RUN cargo build --release --features s3
+COPY --link ./Cargo.toml .
+COPY --link ./build.rs .
+COPY --link ./src ./src
+COPY --link ./tests .
 
-FROM alpine
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=kdi-cargo-registry \
+    --mount=type=cache,target=/usr/local/cargo/git,id=kdi-cargo-git \
+    --mount=type=cache,target=target,id=kdi-target \
+    cargo build --release --features s3 && cp target/release/kafka-delta-ingest .
 
-RUN apk add -U ca-certificates
+FROM debian:12
+
+RUN apt-get update && apt-get -y install \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
-COPY --from=builder /build/target/release/kafka-delta-ingest ./
+COPY --from=builder /build/kafka-delta-ingest ./
 ENTRYPOINT ["/build/kafka-delta-ingest"]


### PR DESCRIPTION
# What Changed

1. utilize docker cache volumes during builds to slightly improve performance
1. set runtime image to same base image distro as the build image

# Why

## 1. cache volumes

A clean build on my local machine takes about 30 mins. This is an attempt to
improve the iteration process by reducing the scope of changes that blow the
docker build cache and using docker volumes for large sections of the image that
are written during `cargo build` reducing recompilation of dependencies during
every docker build.

## 2. debian runtime

The binary produced in by the rust image doesn't run inside the alpine
container. This switches the runtime of the final image to match the upstream
base image of the rust image that is used to build.
