### PR TITLE
Add null-check in coersion tree for tostring, to disregard real nulls

### DIFF
--- a/src/coercions.rs
+++ b/src/coercions.rs
@@ -80,7 +80,7 @@ pub(crate) fn coerce(value: &mut Value, coercion_tree: &CoercionTree) {
 fn apply_coercion(value: &mut Value, node: &CoercionNode) {
     match node {
         CoercionNode::Coercion(Coercion::ToString) => {
-            if !value.is_string() {
+            if !value.is_string() && !value.is_null() {
                 *value = Value::String(value.to_string());
             }
         }


### PR DESCRIPTION
# Issue?
For one of our kafka topics (Azure Eventhub) we receive a payload where data can be delivered as
`{"attribute": null}`. Kafka delta ingest currently treats this as `"null"`, when it is an attribute candidate for a string type column.

# Why does this happen?
In the coercion tree, this is implicitly cast to a string when the target column for this attribute is of string type.
The logic does not check for nulls, and assumes that a proper null is the string value. This is technically wrong.
Fixed that by explicitly disregard nulls in this coercion.

# Result
<img width="1347" height="860" alt="kdi-null-coersion" src="https://github.com/user-attachments/assets/2f6f6eb1-fa1b-4c3e-92af-6194bf23854e" />

We simulated a test where two payloads were sent frequently, one with a proper string, one with a null value.
Here you see the effect post-change, where nulls are now treated as a proper null.